### PR TITLE
Melody Trainer (1/3): note-sequence page, timing rules and playback (Mode 1)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,11 @@
             android:label="@string/title_activity_phthongs_names"
             android:theme="@style/Theme.LearnByzantineMusic" />
         <activity
+            android:name=".trainer.MelodyTrainerActivity"
+            android:exported="false"
+            android:label="@string/title_activity_melody_trainer"
+            android:theme="@style/Theme.LearnByzantineMusic" />
+        <activity
             android:name=".SettingsActivity"
             android:exported="false"
             android:label="@string/title_activity_settings"

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/MainActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : BaseActivity() {
 
         val testimoniesBtn = findViewById<Button>(R.id.testimonies_btn)
         val eightModesBtn = findViewById<Button>(R.id.eight_modes_btn)
+        val melodyTrainerBtn = findViewById<Button>(R.id.melody_trainer_btn)
         val calendarBtn = findViewById<Button>(R.id.calendar_btn)
         val recordingsBtn = findViewById<Button>(R.id.recordings_btn)
         val notesBtn = findViewById<Button>(R.id.notes_btn)
@@ -47,6 +48,7 @@ class MainActivity : BaseActivity() {
 
         testimoniesBtn.setOnClickListener { openTestimonies() }
         eightModesBtn.setOnClickListener { openEightModes() }
+        melodyTrainerBtn.setOnClickListener { openMelodyTrainer() }
         calendarBtn.setOnClickListener { openWeeklyModeCalendar() }
         recordingsBtn.setOnClickListener { openRecordings() }
         notesBtn.setOnClickListener { openNotes() }
@@ -171,6 +173,11 @@ class MainActivity : BaseActivity() {
 
     private fun openEightModes() {
         val intent = Intent(this, EightModesActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun openMelodyTrainer() {
+        val intent = Intent(this, com.johnchourp.learnbyzantinemusic.trainer.MelodyTrainerActivity::class.java)
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyPlaybackPlanner.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyPlaybackPlanner.kt
@@ -1,0 +1,38 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+/** One scheduled note in a playback plan, with absolute start/duration in milliseconds. */
+data class PlannedNoteEvent(
+    val index: Int,
+    val phthong: TrainerPhthong,
+    val frequencyHz: Double,
+    val startMillis: Long,
+    val durationMillis: Long
+) {
+    val endMillis: Long get() = startMillis + durationMillis
+}
+
+/**
+ * Pure, deterministic translation of a [MelodySequence] + [MelodyTempo] into an
+ * absolute-time schedule of note events. It carries no Android dependency so it is fully
+ * unit-testable, and it is shared by Mode 1 playback and (later) the rhythm-timing mode.
+ */
+object MelodyPlaybackPlanner {
+
+    fun plan(sequence: MelodySequence, tempo: MelodyTempo): List<PlannedNoteEvent> {
+        val durations = sequence.effectiveDurationsBeats()
+        var cursor = 0L
+        return sequence.notes.mapIndexed { index, note ->
+            val durationMillis = tempo.beatsToMillis(durations[index])
+            PlannedNoteEvent(
+                index = index,
+                phthong = note.phthong,
+                frequencyHz = note.frequencyHz,
+                startMillis = cursor,
+                durationMillis = durationMillis
+            ).also { cursor += durationMillis }
+        }
+    }
+
+    fun totalDurationMillis(plan: List<PlannedNoteEvent>): Long =
+        plan.lastOrNull()?.endMillis ?: 0L
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequence.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequence.kt
@@ -1,0 +1,30 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import com.johnchourp.learnbyzantinemusic.analysis.ByzantineRhythmMapper
+import com.johnchourp.learnbyzantinemusic.analysis.NeumeRhythmInput
+
+/**
+ * An ordered melody of [TrainerNote]s. Effective per-note durations are derived from
+ * each note's base duration plus its Byzantine rhythm modifiers, reusing the same
+ * [ByzantineRhythmMapper] rules the notation analyzer applies: γοργόν makes its own note
+ * 0.5 χρόνου and shortens the previous note by 0.5 (two phthongi in one χρόνο), κλάσμα
+ * (fraction) adds a whole χρόνο, and so on.
+ */
+class MelodySequence(
+    val notes: List<TrainerNote>,
+    private val rhythmMapper: ByzantineRhythmMapper = ByzantineRhythmMapper()
+) {
+    /** Effective duration in χρόνοι for each note after applying rhythm rules. */
+    fun effectiveDurationsBeats(): List<Float> =
+        rhythmMapper.map(
+            notes.map { note ->
+                NeumeRhythmInput(modifiers = note.modifiers, baseDurationBeats = note.baseDurationBeats)
+            }
+        )
+
+    /** Total length of the melody in χρόνοι once rhythm rules are applied. */
+    fun totalBeats(): Float = effectiveDurationsBeats().sum()
+
+    val size: Int get() = notes.size
+    fun isEmpty(): Boolean = notes.isEmpty()
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
@@ -86,14 +86,18 @@ class MelodySequencePlayer(
         }
 
         val totalMillis = MelodyPlaybackPlanner.totalDurationMillis(plan)
-        workerHandlerLocal.postDelayed({
-            if (playing && token == sessionToken) finish(listener)
-        }, totalMillis)
+        workerHandlerLocal.postDelayed({ finish(listener, token) }, totalMillis)
     }
 
-    private fun finish(listener: Listener?) {
+    private fun finish(listener: Listener?, token: Long) {
+        // Bail if a newer session (a fresh play()/stop()) has superseded this one — otherwise
+        // an old finish could tear down the new session's worker/fade threads.
+        if (token != sessionToken) return
         playing = false
         voices.forEach { it.stop() }
+        // A stop()+play() can slip in during the blocking voices.stop() above; re-check before
+        // touching the shared thread fields so we never quit the new session's handlers.
+        if (token != sessionToken) return
         teardownThreads()
         mainHandler.post { listener?.onFinished(true) }
     }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
@@ -7,22 +7,29 @@ import com.johnchourp.learnbyzantinemusic.modes.PhthongTonePlayer
 import com.johnchourp.learnbyzantinemusic.modes.ToneTimbre
 
 /**
- * Plays a [MelodyPlaybackPlanner] schedule by driving the shared [PhthongTonePlayer].
- * Each note start is scheduled at its **absolute** planned time (and the final stop at the
- * planned total), so the tone player's fade/start latency does not accumulate into tempo
- * drift across the melody. Scheduling runs on a dedicated background thread so that
- * latency never blocks the UI; note-start and completion callbacks are delivered on the
- * main thread for safe view updates.
+ * Plays a [MelodyPlaybackPlanner] schedule with accurate timing.
+ *
+ * Each note start is scheduled at its **absolute** planned time so latency never
+ * accumulates into tempo drift. To keep the scheduler unblocked, two [PhthongTonePlayer]
+ * voices are used in ping-pong: the next note is started on the idle voice (a fast,
+ * non-blocking call) while the previous voice is faded out on a separate thread. This
+ * avoids the previous note's fade/join delay being consumed inside the scheduler path,
+ * which would otherwise make short notes at high tempo fall behind the beat.
+ *
+ * A monotonically increasing session token, checked before and after the (brief) blocking
+ * `start()` call, prevents a note from beginning after [stop] has already cancelled
+ * playback. Note-start and completion callbacks are delivered on the main thread.
  */
 class MelodySequencePlayer(
-    private val tonePlayer: PhthongTonePlayer,
-    private val timbre: ToneTimbre = ToneTimbre.SOFT
+    private val timbre: ToneTimbre = ToneTimbre.SOFT,
+    voiceFactory: () -> PhthongTonePlayer = { PhthongTonePlayer() }
 ) {
     interface Listener {
         fun onNoteStarted(event: PlannedNoteEvent)
         fun onFinished(completed: Boolean)
     }
 
+    private val voices: List<PhthongTonePlayer> = listOf(voiceFactory(), voiceFactory())
     private val mainHandler = Handler(Looper.getMainLooper())
 
     @Volatile
@@ -32,7 +39,16 @@ class MelodySequencePlayer(
     private var workerHandler: Handler? = null
 
     @Volatile
+    private var fadeThread: HandlerThread? = null
+
+    @Volatile
+    private var fadeHandler: Handler? = null
+
+    @Volatile
     private var playing = false
+
+    @Volatile
+    private var sessionToken = 0L
 
     val isPlaying: Boolean get() = playing
 
@@ -42,30 +58,43 @@ class MelodySequencePlayer(
             listener?.onFinished(true)
             return
         }
+        val token = sessionToken + 1
+        sessionToken = token
         playing = true
 
-        val thread = HandlerThread("MelodyTrainerPlayback").apply { start() }
-        val handler = Handler(thread.looper)
-        workerThread = thread
-        workerHandler = handler
+        val worker = HandlerThread("MelodyTrainerPlayback").apply { start() }
+        val fade = HandlerThread("MelodyTrainerFade").apply { start() }
+        val workerHandlerLocal = Handler(worker.looper)
+        workerThread = worker
+        workerHandler = workerHandlerLocal
+        fadeThread = fade
+        fadeHandler = Handler(fade.looper)
 
         for (event in plan) {
-            handler.postDelayed({
-                if (!playing) return@postDelayed
-                tonePlayer.start(event.frequencyHz, timbre)
-                mainHandler.post { if (playing) listener?.onNoteStarted(event) }
+            workerHandlerLocal.postDelayed({
+                if (!playing || token != sessionToken) return@postDelayed
+                val current = voices[event.index % voices.size]
+                val previous = voices[(event.index + 1) % voices.size]
+                current.start(event.frequencyHz, timbre)
+                if (!playing || token != sessionToken) {
+                    current.stop()
+                    return@postDelayed
+                }
+                fadeHandler?.post { previous.stop() }
+                mainHandler.post { if (playing && token == sessionToken) listener?.onNoteStarted(event) }
             }, event.startMillis)
         }
 
         val totalMillis = MelodyPlaybackPlanner.totalDurationMillis(plan)
-        handler.postDelayed({ finish(listener) }, totalMillis)
+        workerHandlerLocal.postDelayed({
+            if (playing && token == sessionToken) finish(listener)
+        }, totalMillis)
     }
 
     private fun finish(listener: Listener?) {
-        if (!playing) return
         playing = false
-        tonePlayer.stop()
-        teardownWorker()
+        voices.forEach { it.stop() }
+        teardownThreads()
         mainHandler.post { listener?.onFinished(true) }
     }
 
@@ -73,16 +102,27 @@ class MelodySequencePlayer(
     fun stop() {
         val wasPlaying = playing
         playing = false
+        sessionToken++
         workerHandler?.removeCallbacksAndMessages(null)
-        teardownWorker()
+        fadeHandler?.removeCallbacksAndMessages(null)
+        teardownThreads()
         if (wasPlaying) {
-            tonePlayer.stop()
+            voices.forEach { it.stop() }
         }
     }
 
-    private fun teardownWorker() {
+    /** Releases the underlying audio resources. The player cannot be reused afterwards. */
+    fun release() {
+        stop()
+        voices.forEach { it.release() }
+    }
+
+    private fun teardownThreads() {
         workerThread?.quit()
         workerThread = null
         workerHandler = null
+        fadeThread?.quit()
+        fadeThread = null
+        fadeHandler = null
     }
 }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
@@ -1,0 +1,106 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import com.johnchourp.learnbyzantinemusic.modes.PhthongTonePlayer
+import com.johnchourp.learnbyzantinemusic.modes.ToneTimbre
+
+/**
+ * Plays a [MelodyPlaybackPlanner] schedule by driving the shared [PhthongTonePlayer] from
+ * note to note. Scheduling runs on a dedicated background thread so the tone player's
+ * fade-out/join never blocks the UI; note-start and completion callbacks are delivered on
+ * the main thread for safe view updates. A short gap between notes keeps repeated phthongi
+ * audibly distinct.
+ */
+class MelodySequencePlayer(
+    private val tonePlayer: PhthongTonePlayer,
+    private val timbre: ToneTimbre = ToneTimbre.SOFT
+) {
+    interface Listener {
+        fun onNoteStarted(event: PlannedNoteEvent)
+        fun onFinished(completed: Boolean)
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var workerThread: HandlerThread? = null
+    private var workerHandler: Handler? = null
+
+    private var plan: List<PlannedNoteEvent> = emptyList()
+    private var listener: Listener? = null
+    private var cursor = 0
+
+    @Volatile
+    private var playing = false
+
+    val isPlaying: Boolean get() = playing
+
+    fun play(plan: List<PlannedNoteEvent>, listener: Listener?) {
+        stop()
+        if (plan.isEmpty()) {
+            listener?.onFinished(true)
+            return
+        }
+        this.plan = plan
+        this.listener = listener
+        cursor = 0
+        playing = true
+
+        val thread = HandlerThread("MelodyTrainerPlayback").apply { start() }
+        workerThread = thread
+        workerHandler = Handler(thread.looper).also { it.post { step() } }
+    }
+
+    private fun step() {
+        if (!playing) return
+        if (cursor >= plan.size) {
+            finish(completed = true)
+            return
+        }
+        val event = plan[cursor]
+        tonePlayer.start(event.frequencyHz, timbre)
+        mainHandler.post { if (playing) listener?.onNoteStarted(event) }
+
+        val gap = NOTE_GAP_MILLIS.coerceAtMost(event.durationMillis / 4)
+        val audibleMillis = (event.durationMillis - gap).coerceAtLeast(MIN_AUDIBLE_MILLIS)
+        val handler = workerHandler ?: return
+        handler.postDelayed({
+            if (!playing) return@postDelayed
+            tonePlayer.stop()
+            handler.postDelayed({
+                if (!playing) return@postDelayed
+                cursor++
+                step()
+            }, gap)
+        }, audibleMillis)
+    }
+
+    private fun finish(completed: Boolean) {
+        playing = false
+        tonePlayer.stop()
+        teardownWorker()
+        mainHandler.post { listener?.onFinished(completed) }
+    }
+
+    /** Stops playback immediately. Safe to call from the main thread and idempotent. */
+    fun stop() {
+        val wasPlaying = playing
+        playing = false
+        workerHandler?.removeCallbacksAndMessages(null)
+        teardownWorker()
+        if (wasPlaying) {
+            tonePlayer.stop()
+        }
+    }
+
+    private fun teardownWorker() {
+        workerThread?.quit()
+        workerThread = null
+        workerHandler = null
+    }
+
+    companion object {
+        const val NOTE_GAP_MILLIS = 45L
+        const val MIN_AUDIBLE_MILLIS = 90L
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequencePlayer.kt
@@ -7,11 +7,12 @@ import com.johnchourp.learnbyzantinemusic.modes.PhthongTonePlayer
 import com.johnchourp.learnbyzantinemusic.modes.ToneTimbre
 
 /**
- * Plays a [MelodyPlaybackPlanner] schedule by driving the shared [PhthongTonePlayer] from
- * note to note. Scheduling runs on a dedicated background thread so the tone player's
- * fade-out/join never blocks the UI; note-start and completion callbacks are delivered on
- * the main thread for safe view updates. A short gap between notes keeps repeated phthongi
- * audibly distinct.
+ * Plays a [MelodyPlaybackPlanner] schedule by driving the shared [PhthongTonePlayer].
+ * Each note start is scheduled at its **absolute** planned time (and the final stop at the
+ * planned total), so the tone player's fade/start latency does not accumulate into tempo
+ * drift across the melody. Scheduling runs on a dedicated background thread so that
+ * latency never blocks the UI; note-start and completion callbacks are delivered on the
+ * main thread for safe view updates.
  */
 class MelodySequencePlayer(
     private val tonePlayer: PhthongTonePlayer,
@@ -23,12 +24,12 @@ class MelodySequencePlayer(
     }
 
     private val mainHandler = Handler(Looper.getMainLooper())
-    private var workerThread: HandlerThread? = null
-    private var workerHandler: Handler? = null
 
-    private var plan: List<PlannedNoteEvent> = emptyList()
-    private var listener: Listener? = null
-    private var cursor = 0
+    @Volatile
+    private var workerThread: HandlerThread? = null
+
+    @Volatile
+    private var workerHandler: Handler? = null
 
     @Volatile
     private var playing = false
@@ -41,45 +42,31 @@ class MelodySequencePlayer(
             listener?.onFinished(true)
             return
         }
-        this.plan = plan
-        this.listener = listener
-        cursor = 0
         playing = true
 
         val thread = HandlerThread("MelodyTrainerPlayback").apply { start() }
+        val handler = Handler(thread.looper)
         workerThread = thread
-        workerHandler = Handler(thread.looper).also { it.post { step() } }
-    }
+        workerHandler = handler
 
-    private fun step() {
-        if (!playing) return
-        if (cursor >= plan.size) {
-            finish(completed = true)
-            return
-        }
-        val event = plan[cursor]
-        tonePlayer.start(event.frequencyHz, timbre)
-        mainHandler.post { if (playing) listener?.onNoteStarted(event) }
-
-        val gap = NOTE_GAP_MILLIS.coerceAtMost(event.durationMillis / 4)
-        val audibleMillis = (event.durationMillis - gap).coerceAtLeast(MIN_AUDIBLE_MILLIS)
-        val handler = workerHandler ?: return
-        handler.postDelayed({
-            if (!playing) return@postDelayed
-            tonePlayer.stop()
+        for (event in plan) {
             handler.postDelayed({
                 if (!playing) return@postDelayed
-                cursor++
-                step()
-            }, gap)
-        }, audibleMillis)
+                tonePlayer.start(event.frequencyHz, timbre)
+                mainHandler.post { if (playing) listener?.onNoteStarted(event) }
+            }, event.startMillis)
+        }
+
+        val totalMillis = MelodyPlaybackPlanner.totalDurationMillis(plan)
+        handler.postDelayed({ finish(listener) }, totalMillis)
     }
 
-    private fun finish(completed: Boolean) {
+    private fun finish(listener: Listener?) {
+        if (!playing) return
         playing = false
         tonePlayer.stop()
         teardownWorker()
-        mainHandler.post { listener?.onFinished(completed) }
+        mainHandler.post { listener?.onFinished(true) }
     }
 
     /** Stops playback immediately. Safe to call from the main thread and idempotent. */
@@ -97,10 +84,5 @@ class MelodySequencePlayer(
         workerThread?.quit()
         workerThread = null
         workerHandler = null
-    }
-
-    companion object {
-        const val NOTE_GAP_MILLIS = 45L
-        const val MIN_AUDIBLE_MILLIS = 90L
     }
 }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTempo.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTempo.kt
@@ -1,0 +1,25 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+/**
+ * Playback tempo expressed in χρόνοι-per-minute (beats per minute). One χρόνος lasts
+ * `60000 / bpm` milliseconds, so a higher bpm makes the timer count faster — the speed
+ * control the trainer page exposes.
+ */
+data class MelodyTempo(val beatsPerMinute: Int) {
+
+    val millisPerBeat: Double get() = MILLIS_PER_MINUTE / beatsPerMinute.coerceAtLeast(1)
+
+    /** Milliseconds a span of [beats] χρόνοι lasts at this tempo. */
+    fun beatsToMillis(beats: Float): Long = (beats.coerceAtLeast(0f) * millisPerBeat).toLong()
+
+    companion object {
+        const val MIN_BPM = 30
+        const val MAX_BPM = 240
+        const val DEFAULT_BPM = 80
+        const val MILLIS_PER_MINUTE = 60_000.0
+
+        fun clampBpm(bpm: Int): Int = bpm.coerceIn(MIN_BPM, MAX_BPM)
+
+        fun of(bpm: Int): MelodyTempo = MelodyTempo(clampBpm(bpm))
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTempo.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTempo.kt
@@ -1,5 +1,7 @@
 package com.johnchourp.learnbyzantinemusic.trainer
 
+import kotlin.math.roundToLong
+
 /**
  * Playback tempo expressed in χρόνοι-per-minute (beats per minute). One χρόνος lasts
  * `60000 / bpm` milliseconds, so a higher bpm makes the timer count faster — the speed
@@ -10,7 +12,7 @@ data class MelodyTempo(val beatsPerMinute: Int) {
     val millisPerBeat: Double get() = MILLIS_PER_MINUTE / beatsPerMinute.coerceAtLeast(1)
 
     /** Milliseconds a span of [beats] χρόνοι lasts at this tempo. */
-    fun beatsToMillis(beats: Float): Long = (beats.coerceAtLeast(0f) * millisPerBeat).toLong()
+    fun beatsToMillis(beats: Float): Long = (beats.coerceAtLeast(0f) * millisPerBeat).roundToLong()
 
     companion object {
         const val MIN_BPM = 30

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
@@ -1,0 +1,365 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import android.graphics.Color
+import android.os.Bundle
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.SeekBar
+import android.widget.TextView
+import androidx.core.view.children
+import com.johnchourp.learnbyzantinemusic.BaseActivity
+import com.johnchourp.learnbyzantinemusic.R
+import com.johnchourp.learnbyzantinemusic.modes.PhthongTonePlayer
+import kotlin.math.roundToInt
+
+/**
+ * Practice page where the user writes a sequence of phthongi (Νη … Ζω), sets how long
+ * each one lasts in χρόνοι, picks a tempo, and plays the melody back (Mode 1). The timing
+ * rules (γοργόν, κλάσμα) are documented at the top and applied through [MelodySequence] /
+ * the shared ByzantineRhythmMapper.
+ */
+class MelodyTrainerActivity : BaseActivity() {
+
+    private val notes = mutableListOf<TrainerNote>()
+    private var currentOctaveShift = 0
+    private var bpm = MelodyTempo.DEFAULT_BPM
+    private var isPlaybackActive = false
+
+    private val tonePlayer = PhthongTonePlayer()
+    private val player by lazy { MelodySequencePlayer(tonePlayer) }
+
+    private lateinit var noteListContainer: LinearLayout
+    private lateinit var emptyHintText: TextView
+    private lateinit var totalBeatsText: TextView
+    private lateinit var octaveValueText: TextView
+    private lateinit var tempoValueText: TextView
+    private lateinit var playButton: Button
+    private lateinit var stopButton: Button
+    private lateinit var clearButton: Button
+    private lateinit var octaveDownButton: Button
+    private lateinit var octaveUpButton: Button
+    private lateinit var tempoSeek: SeekBar
+    private lateinit var addNoteButtonsRow: LinearLayout
+
+    private val noteRowViews = mutableListOf<View>()
+    private var highlightedRow = -1
+
+    private val playerListener = object : MelodySequencePlayer.Listener {
+        override fun onNoteStarted(event: PlannedNoteEvent) = highlightRow(event.index)
+        override fun onFinished(completed: Boolean) = onPlaybackStopped()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.layout_melody_trainer)
+
+        noteListContainer = findViewById(R.id.note_list_container)
+        emptyHintText = findViewById(R.id.empty_hint_text)
+        totalBeatsText = findViewById(R.id.total_beats_text)
+        octaveValueText = findViewById(R.id.octave_value_text)
+        tempoValueText = findViewById(R.id.tempo_value_text)
+        playButton = findViewById(R.id.play_btn)
+        stopButton = findViewById(R.id.stop_btn)
+        clearButton = findViewById(R.id.clear_btn)
+        octaveDownButton = findViewById(R.id.octave_down_btn)
+        octaveUpButton = findViewById(R.id.octave_up_btn)
+        tempoSeek = findViewById(R.id.tempo_seek)
+        addNoteButtonsRow = findViewById(R.id.add_note_buttons_row)
+
+        buildAddNoteButtons()
+        setupOctaveControls()
+        setupTempoControl()
+        setupTransport()
+
+        renderOctave()
+        renderTempo()
+        renderNotes()
+        setGlobalControlsForPlayback(false)
+    }
+
+    private fun buildAddNoteButtons() {
+        for (phthong in TrainerPhthong.ascending) {
+            val button = Button(this).apply {
+                text = phthong.displayName
+                minWidth = dp(48)
+                minimumWidth = dp(48)
+                setOnClickListener { addNote(phthong) }
+            }
+            val params = LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { marginEnd = dp(4) }
+            addNoteButtonsRow.addView(button, params)
+        }
+    }
+
+    private fun setupOctaveControls() {
+        octaveDownButton.setOnClickListener {
+            currentOctaveShift = (currentOctaveShift - 1).coerceAtLeast(MIN_OCTAVE_SHIFT)
+            renderOctave()
+        }
+        octaveUpButton.setOnClickListener {
+            currentOctaveShift = (currentOctaveShift + 1).coerceAtMost(MAX_OCTAVE_SHIFT)
+            renderOctave()
+        }
+    }
+
+    private fun setupTempoControl() {
+        tempoSeek.max = MelodyTempo.MAX_BPM - MelodyTempo.MIN_BPM
+        tempoSeek.progress = bpm - MelodyTempo.MIN_BPM
+        tempoSeek.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                bpm = MelodyTempo.clampBpm(progress + MelodyTempo.MIN_BPM)
+                renderTempo()
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) = Unit
+            override fun onStopTrackingTouch(seekBar: SeekBar?) = Unit
+        })
+    }
+
+    private fun setupTransport() {
+        playButton.setOnClickListener { startPlayback() }
+        stopButton.setOnClickListener { player.stop() }
+        clearButton.setOnClickListener {
+            if (isPlaybackActive) return@setOnClickListener
+            notes.clear()
+            renderNotes()
+        }
+    }
+
+    private fun addNote(phthong: TrainerPhthong) {
+        if (isPlaybackActive) return
+        notes.add(TrainerNote(phthong = phthong, octaveShift = currentOctaveShift))
+        renderNotes()
+    }
+
+    private fun startPlayback() {
+        if (isPlaybackActive || notes.isEmpty()) return
+        val sequence = MelodySequence(notes.toList())
+        val plan = MelodyPlaybackPlanner.plan(sequence, MelodyTempo.of(bpm))
+        if (plan.isEmpty()) return
+        isPlaybackActive = true
+        setGlobalControlsForPlayback(true)
+        renderNotes()
+        player.play(plan, playerListener)
+    }
+
+    private fun onPlaybackStopped() {
+        isPlaybackActive = false
+        clearHighlight()
+        setGlobalControlsForPlayback(false)
+        renderNotes()
+    }
+
+    // region rendering
+
+    private fun renderOctave() {
+        octaveValueText.text = getString(R.string.melody_trainer_octave_label, octaveLabel(currentOctaveShift))
+        octaveDownButton.isEnabled = !isPlaybackActive && currentOctaveShift > MIN_OCTAVE_SHIFT
+        octaveUpButton.isEnabled = !isPlaybackActive && currentOctaveShift < MAX_OCTAVE_SHIFT
+    }
+
+    private fun renderTempo() {
+        tempoValueText.text = getString(R.string.melody_trainer_tempo_value, bpm)
+    }
+
+    private fun renderNotes() {
+        noteListContainer.removeAllViews()
+        noteRowViews.clear()
+        highlightedRow = -1
+
+        notes.forEachIndexed { index, note ->
+            val row = createNoteRow(index, note)
+            noteRowViews.add(row)
+            noteListContainer.addView(row)
+        }
+
+        emptyHintText.visibility = if (notes.isEmpty()) View.VISIBLE else View.GONE
+        val total = MelodySequence(notes.toList()).totalBeats()
+        totalBeatsText.text = getString(R.string.melody_trainer_total_beats, formatBeats(total))
+        playButton.isEnabled = notes.isNotEmpty() && !isPlaybackActive
+        clearButton.isEnabled = notes.isNotEmpty() && !isPlaybackActive
+    }
+
+    private fun createNoteRow(index: Int, note: TrainerNote): View {
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(4), dp(6), dp(4), dp(6))
+        }
+
+        val label = TextView(this).apply {
+            text = "${index + 1}. ${phthongDisplay(note)}"
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 17f)
+        }
+        row.addView(label, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+
+        val durationEditable = !note.hasGorgo && !isPlaybackActive
+
+        row.addView(
+            Button(this).apply {
+                text = "−"
+                minWidth = dp(44)
+                minimumWidth = dp(44)
+                contentDescription = getString(R.string.melody_trainer_duration_decrease)
+                isEnabled = durationEditable
+                setOnClickListener { changeDuration(index, -DURATION_STEP) }
+            },
+            wrapContent()
+        )
+
+        row.addView(
+            TextView(this).apply {
+                text = getString(R.string.melody_trainer_note_duration, effectiveDurationLabel(note))
+                gravity = Gravity.CENTER
+                minWidth = dp(56)
+                setTextSize(TypedValue.COMPLEX_UNIT_SP, 15f)
+            },
+            wrapContent()
+        )
+
+        row.addView(
+            Button(this).apply {
+                text = "+"
+                minWidth = dp(44)
+                minimumWidth = dp(44)
+                contentDescription = getString(R.string.melody_trainer_duration_increase)
+                isEnabled = durationEditable
+                setOnClickListener { changeDuration(index, DURATION_STEP) }
+            },
+            wrapContent()
+        )
+
+        row.addView(
+            Button(this).apply {
+                text = getString(R.string.melody_trainer_gorgo)
+                isAllCaps = false
+                minWidth = dp(64)
+                minimumWidth = dp(64)
+                alpha = if (note.hasGorgo) 1f else 0.45f
+                isEnabled = !isPlaybackActive
+                setOnClickListener { toggleGorgo(index) }
+            },
+            wrapContent()
+        )
+
+        row.addView(
+            Button(this).apply {
+                text = "✕"
+                minWidth = dp(44)
+                minimumWidth = dp(44)
+                contentDescription = getString(R.string.melody_trainer_note_remove)
+                isEnabled = !isPlaybackActive
+                setOnClickListener { removeNote(index) }
+            },
+            wrapContent()
+        )
+
+        return row
+    }
+
+    // endregion
+
+    private fun changeDuration(index: Int, delta: Float) {
+        if (isPlaybackActive) return
+        val note = notes.getOrNull(index) ?: return
+        if (note.hasGorgo) return
+        val updated = (note.baseDurationBeats + delta).coerceIn(MIN_DURATION, MAX_DURATION)
+        notes[index] = note.copy(baseDurationBeats = updated)
+        renderNotes()
+    }
+
+    private fun toggleGorgo(index: Int) {
+        if (isPlaybackActive) return
+        val note = notes.getOrNull(index) ?: return
+        notes[index] = note.withGorgo(!note.hasGorgo)
+        renderNotes()
+    }
+
+    private fun removeNote(index: Int) {
+        if (isPlaybackActive) return
+        if (index !in notes.indices) return
+        notes.removeAt(index)
+        renderNotes()
+    }
+
+    private fun highlightRow(index: Int) {
+        clearHighlight()
+        noteRowViews.getOrNull(index)?.setBackgroundColor(HIGHLIGHT_COLOR)
+        highlightedRow = index
+    }
+
+    private fun clearHighlight() {
+        noteRowViews.getOrNull(highlightedRow)?.setBackgroundColor(Color.TRANSPARENT)
+        highlightedRow = -1
+    }
+
+    private fun setGlobalControlsForPlayback(playing: Boolean) {
+        stopButton.isEnabled = playing
+        playButton.isEnabled = !playing && notes.isNotEmpty()
+        clearButton.isEnabled = !playing && notes.isNotEmpty()
+        tempoSeek.isEnabled = !playing
+        for (button in addNoteButtonsRow.children) {
+            button.isEnabled = !playing
+        }
+        octaveDownButton.isEnabled = !playing && currentOctaveShift > MIN_OCTAVE_SHIFT
+        octaveUpButton.isEnabled = !playing && currentOctaveShift < MAX_OCTAVE_SHIFT
+    }
+
+    private fun phthongDisplay(note: TrainerNote): String {
+        val suffix = when {
+            note.octaveShift > 0 -> "΄".repeat(note.octaveShift)
+            note.octaveShift < 0 -> ",".repeat(-note.octaveShift)
+            else -> ""
+        }
+        return note.phthong.displayName + suffix
+    }
+
+    private fun effectiveDurationLabel(note: TrainerNote): String =
+        if (note.hasGorgo) formatBeats(GORGO_BEATS) else formatBeats(note.baseDurationBeats)
+
+    private fun octaveLabel(shift: Int): String = if (shift > 0) "+$shift" else shift.toString()
+
+    private fun formatBeats(beats: Float): String {
+        val halves = (beats * 2).roundToInt()
+        val whole = halves / 2
+        return if (halves % 2 == 0) whole.toString() else "$whole,5"
+    }
+
+    private fun wrapContent(): LinearLayout.LayoutParams =
+        LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()
+
+    override fun onPause() {
+        super.onPause()
+        if (isPlaybackActive) {
+            player.stop()
+            onPlaybackStopped()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        player.stop()
+        tonePlayer.release()
+    }
+
+    private companion object {
+        const val MIN_OCTAVE_SHIFT = -1
+        const val MAX_OCTAVE_SHIFT = 1
+        const val DURATION_STEP = 0.5f
+        const val MIN_DURATION = 0.5f
+        const val MAX_DURATION = 4.0f
+        const val GORGO_BEATS = 0.5f
+        const val HIGHLIGHT_COLOR = 0x3300C853 // translucent green
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
@@ -295,7 +295,14 @@ class MelodyTrainerActivity : BaseActivity() {
         if (isPlaybackActive) return
         if (index !in notes.indices) return
         notes.removeAt(index)
+        normalizeLeadingGorgo()
         renderNotes()
+    }
+
+    /** γοργόν is invalid on the first note, so strip it if a deletion shifted one to index 0. */
+    private fun normalizeLeadingGorgo() {
+        val first = notes.firstOrNull() ?: return
+        if (first.hasGorgo) notes[0] = first.withGorgo(false)
     }
 
     private fun highlightRow(index: Int) {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
@@ -14,6 +14,8 @@ import androidx.core.view.children
 import com.johnchourp.learnbyzantinemusic.BaseActivity
 import com.johnchourp.learnbyzantinemusic.R
 import com.johnchourp.learnbyzantinemusic.modes.PhthongTonePlayer
+import java.text.DecimalFormatSymbols
+import java.util.Locale
 import kotlin.math.roundToInt
 
 /**
@@ -124,7 +126,7 @@ class MelodyTrainerActivity : BaseActivity() {
 
     private fun setupTransport() {
         playButton.setOnClickListener { startPlayback() }
-        stopButton.setOnClickListener { player.stop() }
+        stopButton.setOnClickListener { stopPlayback() }
         clearButton.setOnClickListener {
             if (isPlaybackActive) return@setOnClickListener
             notes.clear()
@@ -147,6 +149,12 @@ class MelodyTrainerActivity : BaseActivity() {
         setGlobalControlsForPlayback(true)
         renderNotes()
         player.play(plan, playerListener)
+    }
+
+    private fun stopPlayback() {
+        if (!isPlaybackActive) return
+        player.stop()
+        onPlaybackStopped()
     }
 
     private fun onPlaybackStopped() {
@@ -173,20 +181,21 @@ class MelodyTrainerActivity : BaseActivity() {
         noteRowViews.clear()
         highlightedRow = -1
 
+        val effectiveDurations = MelodySequence(notes.toList()).effectiveDurationsBeats()
         notes.forEachIndexed { index, note ->
-            val row = createNoteRow(index, note)
+            val effectiveBeats = effectiveDurations.getOrElse(index) { note.baseDurationBeats }
+            val row = createNoteRow(index, note, effectiveBeats)
             noteRowViews.add(row)
             noteListContainer.addView(row)
         }
 
         emptyHintText.visibility = if (notes.isEmpty()) View.VISIBLE else View.GONE
-        val total = MelodySequence(notes.toList()).totalBeats()
-        totalBeatsText.text = getString(R.string.melody_trainer_total_beats, formatBeats(total))
+        totalBeatsText.text = getString(R.string.melody_trainer_total_beats, formatBeats(effectiveDurations.sum()))
         playButton.isEnabled = notes.isNotEmpty() && !isPlaybackActive
         clearButton.isEnabled = notes.isNotEmpty() && !isPlaybackActive
     }
 
-    private fun createNoteRow(index: Int, note: TrainerNote): View {
+    private fun createNoteRow(index: Int, note: TrainerNote, effectiveBeats: Float): View {
         val row = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
@@ -215,7 +224,7 @@ class MelodyTrainerActivity : BaseActivity() {
 
         row.addView(
             TextView(this).apply {
-                text = getString(R.string.melody_trainer_note_duration, effectiveDurationLabel(note))
+                text = getString(R.string.melody_trainer_note_duration, formatBeats(effectiveBeats))
                 gravity = Gravity.CENTER
                 minWidth = dp(56)
                 setTextSize(TypedValue.COMPLEX_UNIT_SP, 15f)
@@ -320,16 +329,17 @@ class MelodyTrainerActivity : BaseActivity() {
         return note.phthong.displayName + suffix
     }
 
-    private fun effectiveDurationLabel(note: TrainerNote): String =
-        if (note.hasGorgo) formatBeats(GORGO_BEATS) else formatBeats(note.baseDurationBeats)
-
     private fun octaveLabel(shift: Int): String = if (shift > 0) "+$shift" else shift.toString()
 
     private fun formatBeats(beats: Float): String {
         val halves = (beats * 2).roundToInt()
         val whole = halves / 2
-        return if (halves % 2 == 0) whole.toString() else "$whole,5"
+        if (halves % 2 == 0) return whole.toString()
+        val separator = DecimalFormatSymbols.getInstance(currentLocale()).decimalSeparator
+        return "$whole${separator}5"
     }
+
+    private fun currentLocale(): Locale = resources.configuration.locales.get(0)
 
     private fun wrapContent(): LinearLayout.LayoutParams =
         LinearLayout.LayoutParams(
@@ -359,7 +369,6 @@ class MelodyTrainerActivity : BaseActivity() {
         const val DURATION_STEP = 0.5f
         const val MIN_DURATION = 0.5f
         const val MAX_DURATION = 4.0f
-        const val GORGO_BEATS = 0.5f
         const val HIGHLIGHT_COLOR = 0x3300C853 // translucent green
     }
 }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
@@ -13,7 +13,6 @@ import android.widget.TextView
 import androidx.core.view.children
 import com.johnchourp.learnbyzantinemusic.BaseActivity
 import com.johnchourp.learnbyzantinemusic.R
-import com.johnchourp.learnbyzantinemusic.modes.PhthongTonePlayer
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -31,8 +30,7 @@ class MelodyTrainerActivity : BaseActivity() {
     private var bpm = MelodyTempo.DEFAULT_BPM
     private var isPlaybackActive = false
 
-    private val tonePlayer = PhthongTonePlayer()
-    private val player by lazy { MelodySequencePlayer(tonePlayer) }
+    private val player = MelodySequencePlayer()
 
     private lateinit var noteListContainer: LinearLayout
     private lateinit var emptyHintText: TextView
@@ -246,12 +244,14 @@ class MelodyTrainerActivity : BaseActivity() {
 
         row.addView(
             Button(this).apply {
+                // γοργόν shortens the *previous* note, so it is invalid on the first row.
+                val gorgoAllowed = index > 0
                 text = getString(R.string.melody_trainer_gorgo)
                 isAllCaps = false
                 minWidth = dp(64)
                 minimumWidth = dp(64)
                 alpha = if (note.hasGorgo) 1f else 0.45f
-                isEnabled = !isPlaybackActive
+                isEnabled = !isPlaybackActive && gorgoAllowed
                 setOnClickListener { toggleGorgo(index) }
             },
             wrapContent()
@@ -285,6 +285,7 @@ class MelodyTrainerActivity : BaseActivity() {
 
     private fun toggleGorgo(index: Int) {
         if (isPlaybackActive) return
+        if (index == 0) return // γοργόν needs a previous note to shorten
         val note = notes.getOrNull(index) ?: return
         notes[index] = note.withGorgo(!note.hasGorgo)
         renderNotes()
@@ -359,8 +360,7 @@ class MelodyTrainerActivity : BaseActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        player.stop()
-        tonePlayer.release()
+        player.release()
     }
 
     private companion object {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerNote.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerNote.kt
@@ -1,0 +1,31 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import com.johnchourp.learnbyzantinemusic.analysis.ByzantineRhythmMapper
+
+/**
+ * One entry in a trainer melody: a phthong at an octave shift, a base duration in
+ * χρόνοι (beats), and optional Byzantine rhythm modifiers (γοργόν, κλάσμα, …). The
+ * modifier strings reuse the constants from [ByzantineRhythmMapper] so the trainer and
+ * the notation analyzer interpret rhythm identically.
+ */
+data class TrainerNote(
+    val phthong: TrainerPhthong,
+    val octaveShift: Int = 0,
+    val baseDurationBeats: Float = 1f,
+    val modifiers: List<String> = emptyList()
+) {
+    val frequencyHz: Double get() = TrainerPitchTable.frequencyHz(phthong, octaveShift)
+
+    val hasGorgo: Boolean get() = modifiers.contains(ByzantineRhythmMapper.MODIFIER_GORGO)
+    val hasFraction: Boolean get() = modifiers.contains(ByzantineRhythmMapper.MODIFIER_FRACTION)
+
+    fun withGorgo(enabled: Boolean): TrainerNote = withModifier(ByzantineRhythmMapper.MODIFIER_GORGO, enabled)
+    fun withFraction(enabled: Boolean): TrainerNote = withModifier(ByzantineRhythmMapper.MODIFIER_FRACTION, enabled)
+
+    private fun withModifier(modifier: String, enabled: Boolean): TrainerNote {
+        val present = modifiers.contains(modifier)
+        if (present == enabled) return this
+        val updated = if (enabled) modifiers + modifier else modifiers - modifier
+        return copy(modifiers = updated)
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPhthong.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPhthong.kt
@@ -1,0 +1,30 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+/**
+ * The seven Byzantine phthongi (notes) in ascending order, each tagged with its
+ * position in the natural diatonic scale measured in moria above base Νη.
+ *
+ * Byzantine theory divides the octave into 72 moria. In the natural diatonic scale
+ * the phthongi sit at these cumulative moria above Νη:
+ *
+ *     Νη 0, Πα 12, Βου 22, Γα 30, Δι 42, Κε 54, Ζω 64   (Νη' = 72 closes the octave)
+ *
+ * These positions match the diatonic genus used by the 8 Ήχοι screen.
+ */
+enum class TrainerPhthong(val displayName: String, val diatonicMoriaFromNi: Int) {
+    NI("Νη", 0),
+    PA("Πα", 12),
+    VOU("Βου", 22),
+    GA("Γα", 30),
+    DI("Δι", 42),
+    KE("Κε", 54),
+    ZO("Ζω", 64);
+
+    companion object {
+        /** The phthongi in ascending pitch order (Νη … Ζω). */
+        val ascending: List<TrainerPhthong> = values().toList()
+
+        fun fromDisplayName(displayName: String): TrainerPhthong? =
+            values().firstOrNull { it.displayName == displayName }
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchTable.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchTable.kt
@@ -1,0 +1,20 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import kotlin.math.pow
+
+/**
+ * Converts a [TrainerPhthong] (optionally shifted by whole octaves) to a concrete
+ * frequency in Hz, using the natural diatonic scale anchored at Νη = 220 Hz over a
+ * 72-moria octave. This mirrors the moria→frequency formula the 8 Ήχοι screen uses for
+ * its scale diagram so the trainer sounds the same pitches.
+ */
+object TrainerPitchTable {
+    const val BASE_NI_FREQUENCY_HZ = 220.0
+    const val MORIA_PER_OCTAVE = 72.0
+
+    /** Absolute frequency of [phthong], raised/lowered by [octaveShift] whole octaves. */
+    fun frequencyHz(phthong: TrainerPhthong, octaveShift: Int = 0): Double {
+        val moriaFromNi = phthong.diatonicMoriaFromNi + octaveShift * MORIA_PER_OCTAVE
+        return BASE_NI_FREQUENCY_HZ * 2.0.pow(moriaFromNi / MORIA_PER_OCTAVE)
+    }
+}

--- a/app/src/main/res/layout/layout_main_activity.xml
+++ b/app/src/main/res/layout/layout_main_activity.xml
@@ -272,6 +272,22 @@
         android:gravity="center">
 
         <Button
+            android:id="@+id/melody_trainer_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/melody_trainer_open" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="10dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <Button
             android:id="@+id/calendar_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/layout_melody_trainer.xml
+++ b/app/src/main/res/layout/layout_melody_trainer.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/melody_trainer_title"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/melody_trainer_intro"
+            android:textSize="16sp" />
+
+        <!-- Timing rules reference -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="#33888888" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/melody_trainer_rules_title"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:lineSpacingMultiplier="1.15"
+            android:text="@string/melody_trainer_rules_body"
+            android:textSize="15sp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="#33888888" />
+
+        <!-- Add a phthong -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/melody_trainer_add_note_title"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:scrollbars="none">
+
+            <LinearLayout
+                android:id="@+id/add_note_buttons_row"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" />
+        </HorizontalScrollView>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/octave_down_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/melody_trainer_octave_lower"
+                android:minWidth="56dp"
+                android:text="−" />
+
+            <TextView
+                android:id="@+id/octave_value_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:textSize="16sp"
+                tools:text="Οκτάβα: 0" />
+
+            <Button
+                android:id="@+id/octave_up_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/melody_trainer_octave_higher"
+                android:minWidth="56dp"
+                android:text="+" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="#33888888" />
+
+        <!-- Your sequence -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/melody_trainer_sequence_title"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/total_beats_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="15sp"
+            tools:text="Σύνολο: 4 χρόνοι" />
+
+        <TextView
+            android:id="@+id/empty_hint_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/melody_trainer_empty_hint"
+            android:textSize="15sp"
+            android:textStyle="italic" />
+
+        <LinearLayout
+            android:id="@+id/note_list_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="vertical" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="#33888888" />
+
+        <!-- Speed -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/melody_trainer_tempo_title"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tempo_value_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="16sp"
+            tools:text="80 χρόνοι/λεπτό" />
+
+        <SeekBar
+            android:id="@+id/tempo_seek"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp" />
+
+        <!-- Transport -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/play_btn"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/melody_trainer_play" />
+
+            <Button
+                android:id="@+id/stop_btn"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/melody_trainer_stop" />
+
+            <Button
+                android:id="@+id/clear_btn"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/melody_trainer_clear" />
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -692,4 +692,29 @@ Imagine the phthongs placed on a ladder as shown below:</string>
     <string name="notes_status_import_invalid_json">Invalid backup file.</string>
     <string name="notes_status_import_read_failed">Failed to read backup file.</string>
     <string name="notes_status_folder_selected">Backup folder selected.</string>
+
+    <!-- Melody trainer -->
+    <string name="title_activity_melody_trainer">Melody Trainer</string>
+    <string name="melody_trainer_open">Melody Trainer</string>
+    <string name="melody_trainer_title">Melody Trainer — Time &amp; Phthongi</string>
+    <string name="melody_trainer_intro">Write a sequence of phthongi, set how long each one lasts, and hear the melody at the speed you choose.</string>
+    <string name="melody_trainer_rules_title">Timing rules</string>
+    <string name="melody_trainer_rules_body">• Each phthong lasts 1 beat by default.\n• Gorgon: the phthong becomes half a beat (0.5) and takes 0.5 beat from the previous one, so two phthongi are said in one beat.\n• Klasma (apli): adds one whole beat to the phthong.\n• Use the speed control to set how fast the timer counts (beats per minute).</string>
+    <string name="melody_trainer_add_note_title">Add a phthong</string>
+    <string name="melody_trainer_octave_label">Octave: %1$s</string>
+    <string name="melody_trainer_octave_lower">Octave down</string>
+    <string name="melody_trainer_octave_higher">Octave up</string>
+    <string name="melody_trainer_sequence_title">Your sequence</string>
+    <string name="melody_trainer_total_beats">Total: %1$s beats</string>
+    <string name="melody_trainer_empty_hint">You haven\'t added any phthongi yet. Tap a phthong above to start.</string>
+    <string name="melody_trainer_note_duration">%1$s b.</string>
+    <string name="melody_trainer_duration_decrease">Less time</string>
+    <string name="melody_trainer_duration_increase">More time</string>
+    <string name="melody_trainer_gorgo">Gorgon</string>
+    <string name="melody_trainer_note_remove">Remove phthong</string>
+    <string name="melody_trainer_tempo_title">Speed</string>
+    <string name="melody_trainer_tempo_value">%1$d beats/min</string>
+    <string name="melody_trainer_play">Play</string>
+    <string name="melody_trainer_stop">Stop</string>
+    <string name="melody_trainer_clear">Clear</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,4 +683,29 @@
     <string name="notes_status_import_invalid_json">Μη έγκυρο backup αρχείο.</string>
     <string name="notes_status_import_read_failed">Αποτυχία ανάγνωσης backup αρχείου.</string>
     <string name="notes_status_folder_selected">Ο φάκελος backup επιλέχθηκε.</string>
+
+    <!-- Melody trainer (Γυμναστής Μελωδίας) -->
+    <string name="title_activity_melody_trainer">Γυμναστής Μελωδίας</string>
+    <string name="melody_trainer_open">Γυμναστής Μελωδίας</string>
+    <string name="melody_trainer_title">Γυμναστής Μελωδίας — Χρόνος &amp; Φθόγγοι</string>
+    <string name="melody_trainer_intro">Γράψε μια σειρά από φθόγγους, όρισε πόσο χρόνο κρατάει ο καθένας και άκουσε τη μελωδία στην ταχύτητα που θέλεις.</string>
+    <string name="melody_trainer_rules_title">Κανόνες χρόνου</string>
+    <string name="melody_trainer_rules_body">• Κάθε φθόγγος κρατάει 1 χρόνο από προεπιλογή.\n• Γοργόν: ο φθόγγος γίνεται μισός χρόνος (0,5) και «τραβάει» 0,5 χρόνο από τον προηγούμενο, ώστε να ειπωθούν δύο φθόγγοι σε έναν χρόνο.\n• Κλάσμα (απλή): προσθέτει 1 χρόνο στον φθόγγο.\n• Με το κουμπί ταχύτητας ρυθμίζεις πόσο γρήγορα μετράει ο χρόνος (χρόνοι ανά λεπτό).</string>
+    <string name="melody_trainer_add_note_title">Πρόσθεσε φθόγγο</string>
+    <string name="melody_trainer_octave_label">Οκτάβα: %1$s</string>
+    <string name="melody_trainer_octave_lower">Οκτάβα κάτω</string>
+    <string name="melody_trainer_octave_higher">Οκτάβα πάνω</string>
+    <string name="melody_trainer_sequence_title">Η σειρά σου</string>
+    <string name="melody_trainer_total_beats">Σύνολο: %1$s χρόνοι</string>
+    <string name="melody_trainer_empty_hint">Δεν έχεις προσθέσει φθόγγους ακόμα. Πάτησε έναν φθόγγο πιο πάνω για να ξεκινήσεις.</string>
+    <string name="melody_trainer_note_duration">%1$s χρ.</string>
+    <string name="melody_trainer_duration_decrease">Λιγότερος χρόνος</string>
+    <string name="melody_trainer_duration_increase">Περισσότερος χρόνος</string>
+    <string name="melody_trainer_gorgo">Γοργόν</string>
+    <string name="melody_trainer_note_remove">Αφαίρεση φθόγγου</string>
+    <string name="melody_trainer_tempo_title">Ταχύτητα</string>
+    <string name="melody_trainer_tempo_value">%1$d χρόνοι/λεπτό</string>
+    <string name="melody_trainer_play">Αναπαραγωγή</string>
+    <string name="melody_trainer_stop">Διακοπή</string>
+    <string name="melody_trainer_clear">Καθαρισμός</string>
 </resources>

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyPlaybackPlannerTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyPlaybackPlannerTest.kt
@@ -1,0 +1,41 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MelodyPlaybackPlannerTest {
+
+    @Test
+    fun `plan lays notes end to end in absolute time`() {
+        val sequence = MelodySequence(
+            listOf(
+                TrainerNote(TrainerPhthong.NI, baseDurationBeats = 1f),
+                TrainerNote(TrainerPhthong.PA, baseDurationBeats = 2f)
+            )
+        )
+        val plan = MelodyPlaybackPlanner.plan(sequence, MelodyTempo(60)) // 1000 ms per beat
+
+        assertEquals(2, plan.size)
+        assertEquals(0L, plan[0].startMillis)
+        assertEquals(1000L, plan[0].durationMillis)
+        assertEquals(1000L, plan[1].startMillis)
+        assertEquals(2000L, plan[1].durationMillis)
+        assertEquals(3000L, plan[1].endMillis)
+        assertEquals(3000L, MelodyPlaybackPlanner.totalDurationMillis(plan))
+    }
+
+    @Test
+    fun `plan carries each note's frequency`() {
+        val sequence = MelodySequence(listOf(TrainerNote(TrainerPhthong.NI)))
+        val plan = MelodyPlaybackPlanner.plan(sequence, MelodyTempo(120))
+        assertEquals(220.0, plan.single().frequencyHz, 1e-6)
+        assertEquals(TrainerPhthong.NI, plan.single().phthong)
+    }
+
+    @Test
+    fun `empty sequence yields an empty plan`() {
+        val plan = MelodyPlaybackPlanner.plan(MelodySequence(emptyList()), MelodyTempo(80))
+        assertEquals(emptyList<PlannedNoteEvent>(), plan)
+        assertEquals(0L, MelodyPlaybackPlanner.totalDurationMillis(plan))
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequenceTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/MelodySequenceTest.kt
@@ -1,0 +1,45 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MelodySequenceTest {
+
+    private fun note(phthong: TrainerPhthong, beats: Float = 1f) =
+        TrainerNote(phthong = phthong, baseDurationBeats = beats)
+
+    @Test
+    fun `plain notes keep their base durations`() {
+        val sequence = MelodySequence(listOf(note(TrainerPhthong.NI), note(TrainerPhthong.PA, 2f)))
+        assertEquals(listOf(1f, 2f), sequence.effectiveDurationsBeats())
+        assertEquals(3f, sequence.totalBeats())
+    }
+
+    @Test
+    fun `gorgo halves its note and shortens the previous one`() {
+        val sequence = MelodySequence(
+            listOf(
+                note(TrainerPhthong.NI),
+                note(TrainerPhthong.PA).withGorgo(true)
+            )
+        )
+        // Two phthongi share one χρόνο: previous shrinks to 0.5, gorgo note is 0.5.
+        assertEquals(listOf(0.5f, 0.5f), sequence.effectiveDurationsBeats())
+        assertEquals(1f, sequence.totalBeats())
+    }
+
+    @Test
+    fun `fraction adds a whole beat`() {
+        val sequence = MelodySequence(listOf(note(TrainerPhthong.DI).withFraction(true)))
+        assertEquals(listOf(2f), sequence.effectiveDurationsBeats())
+        assertEquals(2f, sequence.totalBeats())
+    }
+
+    @Test
+    fun `empty sequence has no durations`() {
+        val sequence = MelodySequence(emptyList())
+        assertEquals(emptyList<Float>(), sequence.effectiveDurationsBeats())
+        assertEquals(0f, sequence.totalBeats())
+        assertEquals(0, sequence.size)
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTempoTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTempoTest.kt
@@ -1,0 +1,40 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MelodyTempoTest {
+
+    @Test
+    fun `millis per beat follows bpm`() {
+        assertEquals(1000.0, MelodyTempo(60).millisPerBeat, 1e-6)
+        assertEquals(500.0, MelodyTempo(120).millisPerBeat, 1e-6)
+    }
+
+    @Test
+    fun `beats convert to milliseconds`() {
+        val tempo = MelodyTempo(120) // 500 ms per beat
+        assertEquals(500L, tempo.beatsToMillis(1f))
+        assertEquals(250L, tempo.beatsToMillis(0.5f))
+        assertEquals(1000L, tempo.beatsToMillis(2f))
+        assertEquals(0L, tempo.beatsToMillis(0f))
+    }
+
+    @Test
+    fun `negative beats clamp to zero`() {
+        assertEquals(0L, MelodyTempo(120).beatsToMillis(-3f))
+    }
+
+    @Test
+    fun `clampBpm keeps bpm inside the allowed range`() {
+        assertEquals(MelodyTempo.MIN_BPM, MelodyTempo.clampBpm(1))
+        assertEquals(MelodyTempo.MAX_BPM, MelodyTempo.clampBpm(10_000))
+        assertEquals(80, MelodyTempo.clampBpm(80))
+    }
+
+    @Test
+    fun `of builds a clamped tempo`() {
+        assertEquals(MelodyTempo.MAX_BPM, MelodyTempo.of(10_000).beatsPerMinute)
+        assertEquals(MelodyTempo.MIN_BPM, MelodyTempo.of(0).beatsPerMinute)
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerNoteTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerNoteTest.kt
@@ -1,0 +1,41 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import com.johnchourp.learnbyzantinemusic.analysis.ByzantineRhythmMapper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrainerNoteTest {
+
+    @Test
+    fun `note exposes its phthong frequency`() {
+        assertEquals(220.0, TrainerNote(TrainerPhthong.NI).frequencyHz, 1e-6)
+        assertEquals(440.0, TrainerNote(TrainerPhthong.NI, octaveShift = 1).frequencyHz, 1e-6)
+    }
+
+    @Test
+    fun `gorgo toggles on and off without duplicating modifiers`() {
+        val base = TrainerNote(TrainerPhthong.PA)
+        assertFalse(base.hasGorgo)
+
+        val withGorgo = base.withGorgo(true)
+        assertTrue(withGorgo.hasGorgo)
+        assertEquals(listOf(ByzantineRhythmMapper.MODIFIER_GORGO), withGorgo.modifiers)
+
+        // Toggling on again is idempotent.
+        assertEquals(withGorgo, withGorgo.withGorgo(true))
+
+        val withoutGorgo = withGorgo.withGorgo(false)
+        assertFalse(withoutGorgo.hasGorgo)
+        assertEquals(emptyList<String>(), withoutGorgo.modifiers)
+    }
+
+    @Test
+    fun `fraction modifier is tracked independently`() {
+        val note = TrainerNote(TrainerPhthong.DI).withFraction(true)
+        assertTrue(note.hasFraction)
+        assertFalse(note.hasGorgo)
+        assertTrue(note.modifiers.contains(ByzantineRhythmMapper.MODIFIER_FRACTION))
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchTableTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchTableTest.kt
@@ -1,0 +1,41 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrainerPitchTableTest {
+
+    @Test
+    fun `base ni is 220 hz`() {
+        assertEquals(220.0, TrainerPitchTable.frequencyHz(TrainerPhthong.NI), 1e-6)
+    }
+
+    @Test
+    fun `octave shifts double and halve the frequency`() {
+        assertEquals(440.0, TrainerPitchTable.frequencyHz(TrainerPhthong.NI, 1), 1e-6)
+        assertEquals(110.0, TrainerPitchTable.frequencyHz(TrainerPhthong.NI, -1), 1e-6)
+    }
+
+    @Test
+    fun `diatonic phthongi land on expected frequencies`() {
+        // 220 * 2^(moria/72) for the diatonic moria positions.
+        assertEquals(246.94, TrainerPitchTable.frequencyHz(TrainerPhthong.PA), 0.05)
+        assertEquals(293.66, TrainerPitchTable.frequencyHz(TrainerPhthong.GA), 0.05)
+        assertEquals(329.63, TrainerPitchTable.frequencyHz(TrainerPhthong.DI), 0.05)
+        assertEquals(369.99, TrainerPitchTable.frequencyHz(TrainerPhthong.KE), 0.05)
+    }
+
+    @Test
+    fun `frequencies increase strictly across the ascending phthongi`() {
+        val frequencies = TrainerPhthong.ascending.map { TrainerPitchTable.frequencyHz(it) }
+        for (i in 1 until frequencies.size) {
+            assertTrue(
+                "expected ${frequencies[i]} > ${frequencies[i - 1]}",
+                frequencies[i] > frequencies[i - 1]
+            )
+        }
+        // Ζω stays below the next octave Νη'.
+        assertTrue(frequencies.last() < TrainerPitchTable.frequencyHz(TrainerPhthong.NI, 1))
+    }
+}


### PR DESCRIPTION
## Melody Trainer — core page + playback (Mode 1)

Implements the first part of ClickUp task [869dbkkwc](https://app.clickup.com/t/90121749478/869dbkkwc): a new **Γυμναστής Μελωδίας** practice page reachable from the main menu (after 8 Ήχοι).

The user writes a sequence of phthongi (Νη … Ζω, with octave shift), sets each note's duration in χρόνοι, toggles **γοργόν**, picks a tempo, and plays the melody back. The **timing rules** are documented at the top of the page (each phthong = 1 χρόνος by default; γοργόν makes a note 0.5 and takes 0.5 from the previous one → two phthongi in one χρόνο; κλάσμα adds a χρόνο; the speed control sets χρόνοι/λεπτό).

### Core (pure, no Android deps, unit-tested)
- `TrainerPhthong` — the 7 phthongi with their diatonic moria positions.
- `TrainerPitchTable` — phthong (+octave) → Hz via the 72-moria octave at Νη=220 Hz, mirroring the 8 Ήχοι scale formula.
- `TrainerNote` / `MelodySequence` — note model; effective durations reuse the existing `ByzantineRhythmMapper` so trainer and notation analyzer interpret rhythm identically.
- `MelodyTempo` — χρόνοι/min ↔ ms, clamped to 30–240 bpm.
- `MelodyPlaybackPlanner` — deterministic absolute-time schedule of note events.

### Android glue
- `MelodySequencePlayer` — drives the existing `PhthongTonePlayer` note-by-note on a background `HandlerThread` (its fade/join never blocks the UI), reporting the active note on the main thread for highlighting.
- `MelodyTrainerActivity` + `layout_melody_trainer.xml` — the screen.
- Wiring: manifest entry, main-menu button + `MainActivity` handler, Greek (default) + English strings.

### Tests
19 unit tests (pitch table, tempo, sequence/rhythm rules, planner, note model). `assembleDebug` + full unit suite (81 tests) + `check-no-secrets.sh` pass.

This is **PR 1 of 3**; PR 2 (voice-check) and PR 3 (timing exercise) stack on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
