### PR TITLE
Melody Trainer (2/3): voice-check mode — green correctly-sung phthongi (Mode 2)

### DIFF
--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
@@ -1,5 +1,7 @@
 package com.johnchourp.learnbyzantinemusic.trainer
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Bundle
 import android.util.TypedValue
@@ -7,9 +9,13 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import com.johnchourp.learnbyzantinemusic.BaseActivity
 import com.johnchourp.learnbyzantinemusic.R
@@ -18,19 +24,29 @@ import kotlin.math.roundToInt
 
 /**
  * Practice page where the user writes a sequence of phthongi (Νη … Ζω), sets how long
- * each one lasts in χρόνοι, picks a tempo, and plays the melody back (Mode 1). The timing
- * rules (γοργόν, κλάσμα) are documented at the top and applied through [MelodySequence] /
- * the shared ByzantineRhythmMapper.
+ * each one lasts in χρόνοι, picks a tempo, and either:
+ *  - Mode 1: plays the melody back at that tempo, or
+ *  - Mode 2 (voice check): sings the melody while the microphone greens each phthong said
+ *    correctly and advances through the sequence.
+ * The timing rules (γοργόν, κλάσμα) are documented at the top and applied through
+ * [MelodySequence] / the shared ByzantineRhythmMapper.
  */
 class MelodyTrainerActivity : BaseActivity() {
 
     private val notes = mutableListOf<TrainerNote>()
     private var currentOctaveShift = 0
     private var bpm = MelodyTempo.DEFAULT_BPM
+
     private var isPlaybackActive = false
+    private var isVoiceActive = false
+    private var suppressVoiceSwitchCallback = false
 
     private val tonePlayer = PhthongTonePlayer()
     private val player by lazy { MelodySequencePlayer(tonePlayer) }
+    private val pitchEngine by lazy { TrainerPitchEngine(onPitch = ::onPitchDetected) }
+    private var evaluator: PitchGreeningEvaluator? = null
+    private val matchedIndices = mutableSetOf<Int>()
+    private var correctCount = 0
 
     private lateinit var noteListContainer: LinearLayout
     private lateinit var emptyHintText: TextView
@@ -44,9 +60,22 @@ class MelodyTrainerActivity : BaseActivity() {
     private lateinit var octaveUpButton: Button
     private lateinit var tempoSeek: SeekBar
     private lateinit var addNoteButtonsRow: LinearLayout
+    private lateinit var voiceCheckSwitch: CheckBox
+    private lateinit var voiceStatusText: TextView
 
     private val noteRowViews = mutableListOf<View>()
     private var highlightedRow = -1
+
+    private val micPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            startVoiceSession()
+        } else {
+            setVoiceSwitchChecked(false)
+            voiceStatusText.text = getString(R.string.melody_trainer_mic_permission_required)
+        }
+    }
 
     private val playerListener = object : MelodySequencePlayer.Listener {
         override fun onNoteStarted(event: PlannedNoteEvent) = highlightRow(event.index)
@@ -69,16 +98,18 @@ class MelodyTrainerActivity : BaseActivity() {
         octaveUpButton = findViewById(R.id.octave_up_btn)
         tempoSeek = findViewById(R.id.tempo_seek)
         addNoteButtonsRow = findViewById(R.id.add_note_buttons_row)
+        voiceCheckSwitch = findViewById(R.id.voice_check_switch)
+        voiceStatusText = findViewById(R.id.voice_status_text)
 
         buildAddNoteButtons()
         setupOctaveControls()
         setupTempoControl()
         setupTransport()
+        setupVoiceCheck()
 
         renderOctave()
         renderTempo()
         renderNotes()
-        setGlobalControlsForPlayback(false)
     }
 
     private fun buildAddNoteButtons() {
@@ -126,25 +157,64 @@ class MelodyTrainerActivity : BaseActivity() {
         playButton.setOnClickListener { startPlayback() }
         stopButton.setOnClickListener { player.stop() }
         clearButton.setOnClickListener {
-            if (isPlaybackActive) return@setOnClickListener
+            if (isBusy) return@setOnClickListener
             notes.clear()
+            matchedIndices.clear()
             renderNotes()
         }
     }
 
+    private fun setupVoiceCheck() {
+        voiceCheckSwitch.setOnCheckedChangeListener { _, checked ->
+            if (suppressVoiceSwitchCallback) return@setOnCheckedChangeListener
+            if (checked) requestVoiceSession() else stopVoiceSession(clearGreens = true)
+        }
+    }
+
+    // region editing
+
+    private val isBusy: Boolean get() = isPlaybackActive || isVoiceActive
+
     private fun addNote(phthong: TrainerPhthong) {
-        if (isPlaybackActive) return
+        if (isBusy) return
         notes.add(TrainerNote(phthong = phthong, octaveShift = currentOctaveShift))
         renderNotes()
     }
 
+    private fun changeDuration(index: Int, delta: Float) {
+        if (isBusy) return
+        val note = notes.getOrNull(index) ?: return
+        if (note.hasGorgo) return
+        val updated = (note.baseDurationBeats + delta).coerceIn(MIN_DURATION, MAX_DURATION)
+        notes[index] = note.copy(baseDurationBeats = updated)
+        renderNotes()
+    }
+
+    private fun toggleGorgo(index: Int) {
+        if (isBusy) return
+        val note = notes.getOrNull(index) ?: return
+        notes[index] = note.withGorgo(!note.hasGorgo)
+        renderNotes()
+    }
+
+    private fun removeNote(index: Int) {
+        if (isBusy) return
+        if (index !in notes.indices) return
+        notes.removeAt(index)
+        matchedIndices.clear()
+        renderNotes()
+    }
+
+    // endregion
+
+    // region Mode 1: playback
+
     private fun startPlayback() {
-        if (isPlaybackActive || notes.isEmpty()) return
+        if (isBusy || notes.isEmpty()) return
         val sequence = MelodySequence(notes.toList())
         val plan = MelodyPlaybackPlanner.plan(sequence, MelodyTempo.of(bpm))
         if (plan.isEmpty()) return
         isPlaybackActive = true
-        setGlobalControlsForPlayback(true)
         renderNotes()
         player.play(plan, playerListener)
     }
@@ -152,16 +222,116 @@ class MelodyTrainerActivity : BaseActivity() {
     private fun onPlaybackStopped() {
         isPlaybackActive = false
         clearHighlight()
-        setGlobalControlsForPlayback(false)
         renderNotes()
     }
+
+    // endregion
+
+    // region Mode 2: voice check
+
+    private fun requestVoiceSession() {
+        if (isPlaybackActive) {
+            setVoiceSwitchChecked(false)
+            return
+        }
+        if (notes.isEmpty()) {
+            setVoiceSwitchChecked(false)
+            voiceStatusText.text = getString(R.string.melody_trainer_voice_need_notes)
+            return
+        }
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            startVoiceSession()
+        } else {
+            micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+
+    private fun startVoiceSession() {
+        if (notes.isEmpty()) {
+            setVoiceSwitchChecked(false)
+            return
+        }
+        matchedIndices.clear()
+        correctCount = 0
+        evaluator = PitchGreeningEvaluator(notes.map { it.phthong })
+        isVoiceActive = true
+        renderNotes()
+        if (!pitchEngine.start()) {
+            isVoiceActive = false
+            evaluator = null
+            setVoiceSwitchChecked(false)
+            voiceStatusText.text = getString(R.string.melody_trainer_mic_unavailable)
+            renderNotes()
+            return
+        }
+        updateVoiceStatus()
+    }
+
+    private fun onPitchDetected(match: PitchMatch?) {
+        val activeEvaluator = evaluator ?: return
+        if (!isVoiceActive) return
+        val result = activeEvaluator.onFrame(match)
+        if (result != null && result.matched) {
+            matchedIndices.add(result.targetIndex)
+            correctCount++
+            colorRow(result.targetIndex, MATCHED_COLOR)
+        }
+        if (activeEvaluator.isComplete) {
+            finishVoiceSession()
+        } else {
+            updateVoiceStatus()
+        }
+    }
+
+    private fun finishVoiceSession() {
+        pitchEngine.stop()
+        isVoiceActive = false
+        setVoiceSwitchChecked(false)
+        voiceStatusText.text = getString(
+            R.string.melody_trainer_voice_done,
+            correctCount,
+            notes.size
+        )
+        applyControlState()
+    }
+
+    private fun stopVoiceSession(clearGreens: Boolean) {
+        val wasActive = isVoiceActive
+        pitchEngine.stop()
+        isVoiceActive = false
+        evaluator = null
+        if (clearGreens) {
+            matchedIndices.clear()
+        }
+        if (wasActive) {
+            voiceStatusText.text = getString(R.string.melody_trainer_voice_hint)
+        }
+        renderNotes()
+    }
+
+    private fun updateVoiceStatus() {
+        val target = evaluator?.currentTarget() ?: return
+        voiceStatusText.text = getString(R.string.melody_trainer_voice_listening, target.displayName)
+    }
+
+    private fun setVoiceSwitchChecked(checked: Boolean) {
+        suppressVoiceSwitchCallback = true
+        voiceCheckSwitch.isChecked = checked
+        suppressVoiceSwitchCallback = false
+    }
+
+    // endregion
 
     // region rendering
 
     private fun renderOctave() {
         octaveValueText.text = getString(R.string.melody_trainer_octave_label, octaveLabel(currentOctaveShift))
-        octaveDownButton.isEnabled = !isPlaybackActive && currentOctaveShift > MIN_OCTAVE_SHIFT
-        octaveUpButton.isEnabled = !isPlaybackActive && currentOctaveShift < MAX_OCTAVE_SHIFT
+        octaveDownButton.isEnabled = !isBusy && currentOctaveShift > MIN_OCTAVE_SHIFT
+        octaveUpButton.isEnabled = !isBusy && currentOctaveShift < MAX_OCTAVE_SHIFT
     }
 
     private fun renderTempo() {
@@ -182,8 +352,7 @@ class MelodyTrainerActivity : BaseActivity() {
         emptyHintText.visibility = if (notes.isEmpty()) View.VISIBLE else View.GONE
         val total = MelodySequence(notes.toList()).totalBeats()
         totalBeatsText.text = getString(R.string.melody_trainer_total_beats, formatBeats(total))
-        playButton.isEnabled = notes.isNotEmpty() && !isPlaybackActive
-        clearButton.isEnabled = notes.isNotEmpty() && !isPlaybackActive
+        applyControlState()
     }
 
     private fun createNoteRow(index: Int, note: TrainerNote): View {
@@ -191,6 +360,9 @@ class MelodyTrainerActivity : BaseActivity() {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
             setPadding(dp(4), dp(6), dp(4), dp(6))
+            if (matchedIndices.contains(index)) {
+                setBackgroundColor(MATCHED_COLOR)
+            }
         }
 
         val label = TextView(this).apply {
@@ -199,7 +371,7 @@ class MelodyTrainerActivity : BaseActivity() {
         }
         row.addView(label, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
 
-        val durationEditable = !note.hasGorgo && !isPlaybackActive
+        val durationEditable = !note.hasGorgo && !isBusy
 
         row.addView(
             Button(this).apply {
@@ -242,7 +414,7 @@ class MelodyTrainerActivity : BaseActivity() {
                 minWidth = dp(64)
                 minimumWidth = dp(64)
                 alpha = if (note.hasGorgo) 1f else 0.45f
-                isEnabled = !isPlaybackActive
+                isEnabled = !isBusy
                 setOnClickListener { toggleGorgo(index) }
             },
             wrapContent()
@@ -254,38 +426,13 @@ class MelodyTrainerActivity : BaseActivity() {
                 minWidth = dp(44)
                 minimumWidth = dp(44)
                 contentDescription = getString(R.string.melody_trainer_note_remove)
-                isEnabled = !isPlaybackActive
+                isEnabled = !isBusy
                 setOnClickListener { removeNote(index) }
             },
             wrapContent()
         )
 
         return row
-    }
-
-    // endregion
-
-    private fun changeDuration(index: Int, delta: Float) {
-        if (isPlaybackActive) return
-        val note = notes.getOrNull(index) ?: return
-        if (note.hasGorgo) return
-        val updated = (note.baseDurationBeats + delta).coerceIn(MIN_DURATION, MAX_DURATION)
-        notes[index] = note.copy(baseDurationBeats = updated)
-        renderNotes()
-    }
-
-    private fun toggleGorgo(index: Int) {
-        if (isPlaybackActive) return
-        val note = notes.getOrNull(index) ?: return
-        notes[index] = note.withGorgo(!note.hasGorgo)
-        renderNotes()
-    }
-
-    private fun removeNote(index: Int) {
-        if (isPlaybackActive) return
-        if (index !in notes.indices) return
-        notes.removeAt(index)
-        renderNotes()
     }
 
     private fun highlightRow(index: Int) {
@@ -295,21 +442,29 @@ class MelodyTrainerActivity : BaseActivity() {
     }
 
     private fun clearHighlight() {
-        noteRowViews.getOrNull(highlightedRow)?.setBackgroundColor(Color.TRANSPARENT)
+        val restore = if (matchedIndices.contains(highlightedRow)) MATCHED_COLOR else Color.TRANSPARENT
+        noteRowViews.getOrNull(highlightedRow)?.setBackgroundColor(restore)
         highlightedRow = -1
     }
 
-    private fun setGlobalControlsForPlayback(playing: Boolean) {
-        stopButton.isEnabled = playing
-        playButton.isEnabled = !playing && notes.isNotEmpty()
-        clearButton.isEnabled = !playing && notes.isNotEmpty()
-        tempoSeek.isEnabled = !playing
-        for (button in addNoteButtonsRow.children) {
-            button.isEnabled = !playing
-        }
-        octaveDownButton.isEnabled = !playing && currentOctaveShift > MIN_OCTAVE_SHIFT
-        octaveUpButton.isEnabled = !playing && currentOctaveShift < MAX_OCTAVE_SHIFT
+    private fun colorRow(index: Int, color: Int) {
+        noteRowViews.getOrNull(index)?.setBackgroundColor(color)
     }
+
+    private fun applyControlState() {
+        stopButton.isEnabled = isPlaybackActive
+        playButton.isEnabled = !isBusy && notes.isNotEmpty()
+        clearButton.isEnabled = !isBusy && notes.isNotEmpty()
+        tempoSeek.isEnabled = !isBusy
+        voiceCheckSwitch.isEnabled = !isPlaybackActive
+        for (button in addNoteButtonsRow.children) {
+            button.isEnabled = !isBusy
+        }
+        octaveDownButton.isEnabled = !isBusy && currentOctaveShift > MIN_OCTAVE_SHIFT
+        octaveUpButton.isEnabled = !isBusy && currentOctaveShift < MAX_OCTAVE_SHIFT
+    }
+
+    // endregion
 
     private fun phthongDisplay(note: TrainerNote): String {
         val suffix = when {
@@ -345,12 +500,17 @@ class MelodyTrainerActivity : BaseActivity() {
             player.stop()
             onPlaybackStopped()
         }
+        if (isVoiceActive) {
+            setVoiceSwitchChecked(false)
+            stopVoiceSession(clearGreens = false)
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
         player.stop()
         tonePlayer.release()
+        pitchEngine.stop()
     }
 
     private companion object {
@@ -360,6 +520,7 @@ class MelodyTrainerActivity : BaseActivity() {
         const val MIN_DURATION = 0.5f
         const val MAX_DURATION = 4.0f
         const val GORGO_BEATS = 0.5f
-        const val HIGHLIGHT_COLOR = 0x3300C853 // translucent green
+        const val HIGHLIGHT_COLOR = 0x33FFC107 // translucent amber: note currently playing
+        const val MATCHED_COLOR = 0x6600C853 // green: phthong sung correctly
     }
 }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/PitchGreeningEvaluator.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/PitchGreeningEvaluator.kt
@@ -1,0 +1,88 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import kotlin.math.abs
+
+/** Verdict for one target note once the singer has produced a stable phthong for it. */
+data class GreeningResult(
+    val targetIndex: Int,
+    val matched: Boolean,
+    val sungPhthong: TrainerPhthong
+)
+
+/**
+ * Streaming evaluator for the voice-following ("πρασίνισμα") mode. It is fed one detected
+ * [PitchMatch] per analysis frame (null = silence/no pitch) and segments the stream into
+ * sung notes: a phthong held for [minStableFrames] consecutive frames commits the current
+ * target. The target turns green only when the sung phthong equals the expected one within
+ * [toleranceMoria]; either way the evaluator advances to the next target, matching the
+ * "right or wrong, move to the next" behaviour from the feature request.
+ *
+ * Pure logic with no Android dependency, so it is fully unit-testable.
+ */
+class PitchGreeningEvaluator(
+    private val targets: List<TrainerPhthong>,
+    val toleranceMoria: Double = DEFAULT_TOLERANCE_MORIA,
+    private val minStableFrames: Int = DEFAULT_MIN_STABLE_FRAMES
+) {
+    private var index = 0
+    private var candidate: TrainerPhthong? = null
+    private var stableFrames = 0
+    private var segmentCommitted = false
+
+    val currentTargetIndex: Int get() = index
+    val isComplete: Boolean get() = index >= targets.size
+
+    /** Expected phthong the singer should produce next, or null once complete. */
+    fun currentTarget(): TrainerPhthong? = targets.getOrNull(index)
+
+    /**
+     * Feeds one analysis frame. Returns a [GreeningResult] on the frame that commits a
+     * target (so the caller can colour that row and advance), otherwise null.
+     */
+    fun onFrame(match: PitchMatch?): GreeningResult? {
+        if (isComplete) return null
+
+        val phthong = match?.phthong
+        if (phthong == null) {
+            // Silence ends the current sung segment; the next pitch starts a fresh one.
+            resetSegment()
+            return null
+        }
+
+        if (phthong != candidate) {
+            candidate = phthong
+            stableFrames = 1
+            segmentCommitted = false
+            return null
+        }
+
+        stableFrames++
+        if (segmentCommitted || stableFrames < minStableFrames) {
+            return null
+        }
+
+        segmentCommitted = true
+        val target = targets[index]
+        val matched = phthong == target && abs(match.deviationMoria) <= toleranceMoria
+        val result = GreeningResult(targetIndex = index, matched = matched, sungPhthong = phthong)
+        index++
+        return result
+    }
+
+    private fun resetSegment() {
+        candidate = null
+        stableFrames = 0
+        segmentCommitted = false
+    }
+
+    fun reset() {
+        index = 0
+        resetSegment()
+    }
+
+    companion object {
+        /** ±4 moria ≈ ±67 cents — a forgiving but meaningful intonation window. */
+        const val DEFAULT_TOLERANCE_MORIA = 4.0
+        const val DEFAULT_MIN_STABLE_FRAMES = 3
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchEngine.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchEngine.kt
@@ -1,0 +1,135 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.RequiresPermission
+import kotlin.math.sqrt
+
+/**
+ * Captures the microphone, slices it into analysis windows, runs [YinPitchDetector] on
+ * each, maps the result to the nearest phthong, and delivers it on the main thread. A
+ * loudness gate suppresses background hiss so silence reads as "no pitch" rather than a
+ * spurious note. The caller must hold RECORD_AUDIO before calling [start].
+ */
+class TrainerPitchEngine(
+    private val onPitch: (PitchMatch?) -> Unit,
+    private val sampleRate: Int = DEFAULT_SAMPLE_RATE,
+    private val windowSize: Int = DEFAULT_WINDOW_SIZE
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var audioRecord: AudioRecord? = null
+    private var captureThread: Thread? = null
+
+    @Volatile
+    private var running = false
+
+    val isRunning: Boolean get() = running
+
+    @RequiresPermission(Manifest.permission.RECORD_AUDIO)
+    fun start(): Boolean {
+        stop()
+        val minBuffer = AudioRecord.getMinBufferSize(
+            sampleRate,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT
+        )
+        if (minBuffer <= 0) return false
+        val bufferSize = maxOf(minBuffer, windowSize * 2)
+
+        val recorder = buildRecorder(bufferSize) ?: return false
+        if (recorder.state != AudioRecord.STATE_INITIALIZED) {
+            recorder.release()
+            return false
+        }
+
+        audioRecord = recorder
+        running = true
+        return try {
+            recorder.startRecording()
+            captureThread = Thread({ captureLoop(recorder) }, "TrainerPitchEngine").apply {
+                isDaemon = true
+                start()
+            }
+            true
+        } catch (_: IllegalStateException) {
+            stop()
+            false
+        }
+    }
+
+    @SuppressLint("MissingPermission") // start() is annotated @RequiresPermission(RECORD_AUDIO)
+    private fun buildRecorder(bufferSize: Int): AudioRecord? =
+        try {
+            AudioRecord(
+                MediaRecorder.AudioSource.MIC,
+                sampleRate,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bufferSize
+            )
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    private fun captureLoop(recorder: AudioRecord) {
+        val shortBuffer = ShortArray(windowSize)
+        val floatBuffer = FloatArray(windowSize)
+        while (running) {
+            var read = 0
+            while (read < windowSize && running) {
+                val r = recorder.read(shortBuffer, read, windowSize - read)
+                if (r <= 0) break
+                read += r
+            }
+            if (!running || read < windowSize) continue
+
+            for (i in 0 until windowSize) {
+                floatBuffer[i] = shortBuffer[i] / SHORT_FULL_SCALE
+            }
+
+            val match = if (rootMeanSquare(floatBuffer) < SILENCE_RMS) {
+                null
+            } else {
+                val frequency = YinPitchDetector.detect(floatBuffer, sampleRate)
+                if (frequency <= 0f) null else TrainerPitchTable.nearestPhthong(frequency.toDouble())
+            }
+            mainHandler.post { if (running) onPitch(match) }
+        }
+    }
+
+    fun stop() {
+        running = false
+        captureThread = null
+        val recorder = audioRecord
+        audioRecord = null
+        if (recorder != null) {
+            try {
+                recorder.stop()
+            } catch (_: IllegalStateException) {
+                // Already stopped.
+            }
+            recorder.release()
+        }
+        mainHandler.removeCallbacksAndMessages(null)
+    }
+
+    private fun rootMeanSquare(samples: FloatArray): Double {
+        var sum = 0.0
+        for (sample in samples) {
+            sum += sample * sample
+        }
+        return sqrt(sum / samples.size)
+    }
+
+    companion object {
+        const val DEFAULT_SAMPLE_RATE = 44_100
+        const val DEFAULT_WINDOW_SIZE = 2_048
+        private const val SHORT_FULL_SCALE = 32_768f
+        private const val SILENCE_RMS = 0.012
+    }
+}

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchTable.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchTable.kt
@@ -1,20 +1,69 @@
 package com.johnchourp.learnbyzantinemusic.trainer
 
+import kotlin.math.abs
+import kotlin.math.log2
 import kotlin.math.pow
 
 /**
- * Converts a [TrainerPhthong] (optionally shifted by whole octaves) to a concrete
- * frequency in Hz, using the natural diatonic scale anchored at Νη = 220 Hz over a
- * 72-moria octave. This mirrors the moria→frequency formula the 8 Ήχοι screen uses for
- * its scale diagram so the trainer sounds the same pitches.
+ * Converts between [TrainerPhthong]s and concrete frequencies in Hz using the natural
+ * diatonic scale anchored at Νη = 220 Hz over a 72-moria octave. This mirrors the
+ * moria→frequency formula the 8 Ήχοι screen uses for its scale diagram so the trainer
+ * sounds — and listens for — the same pitches.
  */
 object TrainerPitchTable {
     const val BASE_NI_FREQUENCY_HZ = 220.0
     const val MORIA_PER_OCTAVE = 72.0
+    private const val CENTS_PER_OCTAVE = 1200.0
 
     /** Absolute frequency of [phthong], raised/lowered by [octaveShift] whole octaves. */
     fun frequencyHz(phthong: TrainerPhthong, octaveShift: Int = 0): Double {
         val moriaFromNi = phthong.diatonicMoriaFromNi + octaveShift * MORIA_PER_OCTAVE
         return BASE_NI_FREQUENCY_HZ * 2.0.pow(moriaFromNi / MORIA_PER_OCTAVE)
     }
+
+    /** Moria above base Νη for a detected frequency (can be negative or exceed 72). */
+    fun moriaFromNi(frequencyHz: Double): Double =
+        MORIA_PER_OCTAVE * log2(frequencyHz / BASE_NI_FREQUENCY_HZ)
+
+    fun moriaToCents(moria: Double): Double = moria * (CENTS_PER_OCTAVE / MORIA_PER_OCTAVE)
+
+    /**
+     * Nearest phthong (folding octaves away) to a detected frequency, with the signed
+     * deviation in moria: positive = the sung pitch is sharp (above the phthong), negative
+     * = flat. Returns null for non-positive / non-finite input.
+     */
+    fun nearestPhthong(frequencyHz: Double): PitchMatch? {
+        if (frequencyHz <= 0.0 || frequencyHz.isNaN() || frequencyHz.isInfinite()) {
+            return null
+        }
+        val moria = moriaFromNi(frequencyHz)
+        val withinOctave = ((moria % MORIA_PER_OCTAVE) + MORIA_PER_OCTAVE) % MORIA_PER_OCTAVE
+        var best = TrainerPhthong.NI
+        var bestDeviation = Double.MAX_VALUE
+        for (phthong in TrainerPhthong.ascending) {
+            // Compare against the phthong and its upper-octave image so pitches near the
+            // octave seam (Ζω ↔ Νη') resolve to the genuinely closest phthong.
+            val candidates = doubleArrayOf(
+                phthong.diatonicMoriaFromNi.toDouble(),
+                phthong.diatonicMoriaFromNi + MORIA_PER_OCTAVE
+            )
+            for (candidateMoria in candidates) {
+                val deviation = withinOctave - candidateMoria
+                if (abs(deviation) < abs(bestDeviation)) {
+                    bestDeviation = deviation
+                    best = phthong
+                }
+            }
+        }
+        return PitchMatch(best, bestDeviation)
+    }
+}
+
+/** Result of matching a detected frequency to the nearest phthong. */
+data class PitchMatch(
+    val phthong: TrainerPhthong,
+    /** Signed moria deviation from [phthong]: positive = sharp, negative = flat. */
+    val deviationMoria: Double
+) {
+    val deviationCents: Double get() = TrainerPitchTable.moriaToCents(deviationMoria)
 }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/YinPitchDetector.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/YinPitchDetector.kt
@@ -1,0 +1,85 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+/**
+ * Monophonic fundamental-frequency estimator using the YIN algorithm
+ * (de Cheveigné & Kawahara, 2002). It is well suited to a single sung voice and carries
+ * no Android dependency, so it is fully unit-testable on synthetic waveforms.
+ *
+ * [detect] returns the estimated frequency in Hz, or a non-positive value when no
+ * confident pitch is found (silence, noise, or out of the singing range).
+ */
+object YinPitchDetector {
+    const val DEFAULT_THRESHOLD = 0.15
+    const val MIN_FREQUENCY_HZ = 70.0
+    const val MAX_FREQUENCY_HZ = 1200.0
+
+    fun detect(
+        samples: FloatArray,
+        sampleRate: Int,
+        threshold: Double = DEFAULT_THRESHOLD
+    ): Float {
+        val n = samples.size
+        val half = n / 2
+        if (half < 4 || sampleRate <= 0) return -1f
+
+        val yin = DoubleArray(half)
+
+        // Step 1: difference function.
+        for (tau in 0 until half) {
+            var sum = 0.0
+            for (i in 0 until half) {
+                val delta = (samples[i] - samples[i + tau]).toDouble()
+                sum += delta * delta
+            }
+            yin[tau] = sum
+        }
+
+        // Step 2: cumulative mean normalized difference.
+        yin[0] = 1.0
+        var runningSum = 0.0
+        for (tau in 1 until half) {
+            runningSum += yin[tau]
+            yin[tau] = if (runningSum <= 0.0) 1.0 else yin[tau] * tau / runningSum
+        }
+
+        // Step 3: absolute threshold within the plausible singing range.
+        val minTau = (sampleRate / MAX_FREQUENCY_HZ).toInt().coerceAtLeast(2)
+        val maxTau = (sampleRate / MIN_FREQUENCY_HZ).toInt().coerceAtMost(half - 1)
+        if (minTau >= maxTau) return -1f
+
+        var tauEstimate = -1
+        var tau = minTau
+        while (tau <= maxTau) {
+            if (yin[tau] < threshold) {
+                while (tau + 1 <= maxTau && yin[tau + 1] < yin[tau]) {
+                    tau++
+                }
+                tauEstimate = tau
+                break
+            }
+            tau++
+        }
+        if (tauEstimate == -1) return -1f
+
+        // Step 4: parabolic interpolation for sub-sample period accuracy.
+        val betterTau = parabolicInterpolation(yin, tauEstimate)
+        if (betterTau <= 0.0) return -1f
+
+        val frequency = sampleRate / betterTau
+        if (frequency < MIN_FREQUENCY_HZ || frequency > MAX_FREQUENCY_HZ) return -1f
+        return frequency.toFloat()
+    }
+
+    private fun parabolicInterpolation(yin: DoubleArray, tau: Int): Double {
+        val x0 = if (tau < 1) tau else tau - 1
+        val x2 = if (tau + 1 < yin.size) tau + 1 else tau
+        if (x0 == tau) return if (yin[tau] <= yin[x2]) tau.toDouble() else x2.toDouble()
+        if (x2 == tau) return if (yin[tau] <= yin[x0]) tau.toDouble() else x0.toDouble()
+        val s0 = yin[x0]
+        val s1 = yin[tau]
+        val s2 = yin[x2]
+        val denominator = 2.0 * (2.0 * s1 - s2 - s0)
+        if (denominator == 0.0) return tau.toDouble()
+        return tau + (s2 - s0) / denominator
+    }
+}

--- a/app/src/main/res/layout/layout_melody_trainer.xml
+++ b/app/src/main/res/layout/layout_melody_trainer.xml
@@ -207,5 +207,29 @@
                 android:layout_weight="1"
                 android:text="@string/melody_trainer_clear" />
         </LinearLayout>
+
+        <!-- Voice check (Mode 2): greens correctly-sung phthongi -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="#33888888" />
+
+        <CheckBox
+            android:id="@+id/voice_check_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/melody_trainer_voice_check"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/voice_status_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/melody_trainer_voice_hint"
+            android:textSize="15sp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -717,4 +717,11 @@ Imagine the phthongs placed on a ladder as shown below:</string>
     <string name="melody_trainer_play">Play</string>
     <string name="melody_trainer_stop">Stop</string>
     <string name="melody_trainer_clear">Clear</string>
+    <string name="melody_trainer_voice_check">Voice check</string>
+    <string name="melody_trainer_voice_hint">Turn on voice check and sing the melody; phthongi you sing correctly turn green.</string>
+    <string name="melody_trainer_voice_listening">Listening… Sing: %1$s</string>
+    <string name="melody_trainer_voice_done">Done! Correct phthongi: %1$d/%2$d</string>
+    <string name="melody_trainer_voice_need_notes">Add some phthongi first to use voice check.</string>
+    <string name="melody_trainer_mic_permission_required">Microphone permission is required for voice check.</string>
+    <string name="melody_trainer_mic_unavailable">The microphone is not available right now.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -708,4 +708,11 @@
     <string name="melody_trainer_play">Αναπαραγωγή</string>
     <string name="melody_trainer_stop">Διακοπή</string>
     <string name="melody_trainer_clear">Καθαρισμός</string>
+    <string name="melody_trainer_voice_check">Φωνητικός έλεγχος</string>
+    <string name="melody_trainer_voice_hint">Άναψε τον φωνητικό έλεγχο και τραγούδησε τη μελωδία· οι φθόγγοι που λες σωστά πρασινίζουν.</string>
+    <string name="melody_trainer_voice_listening">Άκουσμα… Τραγούδησε: %1$s</string>
+    <string name="melody_trainer_voice_done">Ολοκληρώθηκε! Σωστοί φθόγγοι: %1$d/%2$d</string>
+    <string name="melody_trainer_voice_need_notes">Πρόσθεσε πρώτα φθόγγους για να χρησιμοποιήσεις τον φωνητικό έλεγχο.</string>
+    <string name="melody_trainer_mic_permission_required">Χρειάζεται άδεια μικροφώνου για τον φωνητικό έλεγχο.</string>
+    <string name="melody_trainer_mic_unavailable">Το μικρόφωνο δεν είναι διαθέσιμο αυτή τη στιγμή.</string>
 </resources>

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/PitchGreeningEvaluatorTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/PitchGreeningEvaluatorTest.kt
@@ -1,0 +1,87 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PitchGreeningEvaluatorTest {
+
+    private val stableFrames = 3
+
+    private fun match(phthong: TrainerPhthong, deviation: Double = 0.0) = PitchMatch(phthong, deviation)
+
+    /** Feeds the same phthong [stableFrames] times and returns the committing result. */
+    private fun PitchGreeningEvaluator.sing(phthong: TrainerPhthong, deviation: Double = 0.0): GreeningResult? {
+        var committed: GreeningResult? = null
+        repeat(stableFrames) {
+            val r = onFrame(match(phthong, deviation))
+            if (r != null) committed = r
+        }
+        onFrame(null) // release the note (silence) before the next segment
+        return committed
+    }
+
+    @Test
+    fun `correctly sung phthongi commit as matched and advance`() {
+        val evaluator = PitchGreeningEvaluator(
+            listOf(TrainerPhthong.NI, TrainerPhthong.PA, TrainerPhthong.GA),
+            minStableFrames = stableFrames
+        )
+
+        val first = evaluator.sing(TrainerPhthong.NI)
+        assertEquals(GreeningResult(0, true, TrainerPhthong.NI), first)
+        assertEquals(1, evaluator.currentTargetIndex)
+
+        evaluator.sing(TrainerPhthong.PA)
+        val third = evaluator.sing(TrainerPhthong.GA)
+        assertEquals(GreeningResult(2, true, TrainerPhthong.GA), third)
+        assertTrue(evaluator.isComplete)
+    }
+
+    @Test
+    fun `a wrong phthong still advances but is not matched`() {
+        val evaluator = PitchGreeningEvaluator(
+            listOf(TrainerPhthong.NI, TrainerPhthong.PA),
+            minStableFrames = stableFrames
+        )
+        val result = evaluator.sing(TrainerPhthong.DI) // expected Νη, sang Δι
+        assertEquals(GreeningResult(0, false, TrainerPhthong.DI), result)
+        assertEquals(1, evaluator.currentTargetIndex)
+    }
+
+    @Test
+    fun `intonation outside tolerance is not matched`() {
+        val evaluator = PitchGreeningEvaluator(
+            listOf(TrainerPhthong.NI),
+            toleranceMoria = 4.0,
+            minStableFrames = stableFrames
+        )
+        val result = evaluator.sing(TrainerPhthong.NI, deviation = 6.0) // right phthong, too sharp
+        assertEquals(GreeningResult(0, false, TrainerPhthong.NI), result)
+    }
+
+    @Test
+    fun `a phthong held too briefly does not commit`() {
+        val evaluator = PitchGreeningEvaluator(
+            listOf(TrainerPhthong.NI),
+            minStableFrames = stableFrames
+        )
+        assertNull(evaluator.onFrame(match(TrainerPhthong.NI)))
+        assertNull(evaluator.onFrame(match(TrainerPhthong.NI)))
+        assertEquals(0, evaluator.currentTargetIndex)
+        assertFalse(evaluator.isComplete)
+    }
+
+    @Test
+    fun `reset returns to the first target`() {
+        val evaluator = PitchGreeningEvaluator(listOf(TrainerPhthong.NI, TrainerPhthong.PA), minStableFrames = stableFrames)
+        evaluator.sing(TrainerPhthong.NI)
+        assertEquals(1, evaluator.currentTargetIndex)
+        evaluator.reset()
+        assertEquals(0, evaluator.currentTargetIndex)
+        assertFalse(evaluator.isComplete)
+        assertEquals(TrainerPhthong.NI, evaluator.currentTarget())
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchMatchTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/TrainerPitchMatchTest.kt
@@ -1,0 +1,49 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+class TrainerPitchMatchTest {
+
+    @Test
+    fun `exact phthong frequencies match with no deviation`() {
+        for (phthong in TrainerPhthong.ascending) {
+            val match = TrainerPitchTable.nearestPhthong(TrainerPitchTable.frequencyHz(phthong))
+            assertEquals(phthong, match?.phthong)
+            assertTrue("deviation ${match?.deviationMoria}", abs(match!!.deviationMoria) < 1e-6)
+        }
+    }
+
+    @Test
+    fun `octaves fold onto the same phthong`() {
+        assertEquals(TrainerPhthong.NI, TrainerPitchTable.nearestPhthong(440.0)?.phthong)
+        assertEquals(TrainerPhthong.NI, TrainerPitchTable.nearestPhthong(110.0)?.phthong)
+        assertEquals(TrainerPhthong.DI, TrainerPitchTable.nearestPhthong(TrainerPitchTable.frequencyHz(TrainerPhthong.DI, 1))?.phthong)
+    }
+
+    @Test
+    fun `a slightly sharp pitch reports positive moria deviation`() {
+        // 2 moria above Νη.
+        val twoMoriaSharp = TrainerPitchTable.BASE_NI_FREQUENCY_HZ * Math.pow(2.0, 2.0 / 72.0)
+        val match = TrainerPitchTable.nearestPhthong(twoMoriaSharp)
+        assertEquals(TrainerPhthong.NI, match?.phthong)
+        assertEquals(2.0, match!!.deviationMoria, 0.05)
+    }
+
+    @Test
+    fun `invalid frequencies return null`() {
+        assertNull(TrainerPitchTable.nearestPhthong(0.0))
+        assertNull(TrainerPitchTable.nearestPhthong(-100.0))
+        assertNull(TrainerPitchTable.nearestPhthong(Double.NaN))
+        assertNull(TrainerPitchTable.nearestPhthong(Double.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun `moria converts to cents`() {
+        assertEquals(16.667, TrainerPitchTable.moriaToCents(1.0), 0.01)
+        assertEquals(1200.0, TrainerPitchTable.moriaToCents(72.0), 1e-6)
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/YinPitchDetectorTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/YinPitchDetectorTest.kt
@@ -1,0 +1,48 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.sin
+
+class YinPitchDetectorTest {
+
+    private val sampleRate = 44_100
+    private val windowSize = 2_048
+
+    private fun sine(frequencyHz: Double, harmonicGain: Double = 0.0): FloatArray =
+        FloatArray(windowSize) { i ->
+            val t = i.toDouble() / sampleRate
+            val fundamental = sin(2.0 * PI * frequencyHz * t)
+            val harmonic = harmonicGain * sin(2.0 * PI * 2.0 * frequencyHz * t)
+            (0.9 * (fundamental + harmonic)).toFloat()
+        }
+
+    private fun assertNear(expected: Double, actual: Float, tolerancePercent: Double) {
+        val tolerance = expected * tolerancePercent
+        assertEquals("detected $actual, expected ~$expected", expected, actual.toDouble(), tolerance)
+    }
+
+    @Test
+    fun `detects pure sine fundamentals`() {
+        assertNear(220.0, YinPitchDetector.detect(sine(220.0), sampleRate), 0.01)
+        assertNear(330.0, YinPitchDetector.detect(sine(330.0), sampleRate), 0.01)
+        assertNear(440.0, YinPitchDetector.detect(sine(440.0), sampleRate), 0.01)
+    }
+
+    @Test
+    fun `detects the fundamental of a tone with a harmonic`() {
+        assertNear(246.94, YinPitchDetector.detect(sine(246.94, harmonicGain = 0.4), sampleRate), 0.015)
+    }
+
+    @Test
+    fun `returns no pitch for silence`() {
+        assertTrue(YinPitchDetector.detect(FloatArray(windowSize), sampleRate) <= 0f)
+    }
+
+    @Test
+    fun `returns no pitch for a too-small buffer`() {
+        assertTrue(YinPitchDetector.detect(FloatArray(4), sampleRate) <= 0f)
+    }
+}


### PR DESCRIPTION
## Melody Trainer — voice check (Mode 2)

Implements the voice-following part of ClickUp task [869dbkkwc](https://app.clickup.com/t/90121749478/869dbkkwc). Stacks on #49.

Adds the **Φωνητικός έλεγχος** toggle: with it on, the user sings the melody and each phthong said correctly turns **green** while the trainer advances through the sequence (right or wrong, it moves to the next note), recognising the moria/intonation accuracy.

### Core (pure, no Android deps, unit-tested)
- `YinPitchDetector` — monophonic fundamental-frequency estimation via the YIN algorithm, suited to a single sung voice; verified on synthetic sines.
- `TrainerPitchTable.nearestPhthong` / `PitchMatch` — maps a detected frequency to the nearest phthong (folding octaves) with the signed moria deviation; exposes moria↔cents.
- `PitchGreeningEvaluator` — streaming state machine that segments the sung stream into notes (a phthong held for N frames), matches each against the expected phthong within a moria tolerance, and advances.

### Android glue
- `TrainerPitchEngine` — `AudioRecord` capture sliced into analysis windows, gated by an RMS loudness threshold, feeding YIN and reporting the nearest phthong on the main thread. Reuses the existing `RECORD_AUDIO` permission already declared in the manifest.
- `MelodyTrainerActivity` — voice-check toggle with runtime mic-permission flow, row greening, and mutual exclusion with Mode 1 playback. The playback highlight is recoloured to amber so it reads distinctly from the green "sung correctly" state.

### Tests
14 new unit tests (YIN, pitch matching, greening evaluator); 33 trainer tests. Full suite (81 tests) + `check-no-secrets.sh` pass.

**PR 2 of 3.** Base is `feat/melody-trainer-core` (#49); review the incremental diff here.

> Note: the microphone behaviour is verified on a real device via `$learn-byzantine-live-fix-loop` before the production release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
