### PR TITLE
Melody Trainer (3/3): timing exercise — green on-time notes (Mode 3)

### DIFF
--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/MelodyTrainerActivity.kt
@@ -4,6 +4,9 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
@@ -13,7 +16,6 @@ import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.TextView
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
@@ -24,10 +26,11 @@ import kotlin.math.roundToInt
 
 /**
  * Practice page where the user writes a sequence of phthongi (Νη … Ζω), sets how long
- * each one lasts in χρόνοι, picks a tempo, and either:
- *  - Mode 1: plays the melody back at that tempo, or
- *  - Mode 2 (voice check): sings the melody while the microphone greens each phthong said
- *    correctly and advances through the sequence.
+ * each one lasts in χρόνοι, picks a tempo, and then either:
+ *  - Mode 1: plays the melody back at that tempo,
+ *  - Mode 2 (voice check): sings while the mic greens each phthong said correctly, or
+ *  - Mode 3 (timing exercise): after a 5-second countdown, sings each phthong on time and
+ *    the notes said in the right χρόνο turn green.
  * The timing rules (γοργόν, κλάσμα) are documented at the top and applied through
  * [MelodySequence] / the shared ByzantineRhythmMapper.
  */
@@ -39,14 +42,29 @@ class MelodyTrainerActivity : BaseActivity() {
 
     private var isPlaybackActive = false
     private var isVoiceActive = false
+    private var isRhythmActive = false
     private var suppressVoiceSwitchCallback = false
+    private var suppressRhythmSwitchCallback = false
 
     private val tonePlayer = PhthongTonePlayer()
     private val player by lazy { MelodySequencePlayer(tonePlayer) }
     private val pitchEngine by lazy { TrainerPitchEngine(onPitch = ::onPitchDetected) }
-    private var evaluator: PitchGreeningEvaluator? = null
+    private val uiHandler = Handler(Looper.getMainLooper())
+
+    private var voiceEvaluator: PitchGreeningEvaluator? = null
+    private var voiceCorrectCount = 0
+
+    private var rhythmEvaluator: RhythmTimingEvaluator? = null
+    private var rhythmPlan: List<PlannedNoteEvent> = emptyList()
+    private var rhythmStartMillis = -1L
+    private var rhythmTotalMillis = 0L
+    private var rhythmCorrectCount = 0
+    private var countdownRemaining = 0
+
     private val matchedIndices = mutableSetOf<Int>()
-    private var correctCount = 0
+
+    private var pendingMicGrant: (() -> Unit)? = null
+    private var pendingMicDeny: (() -> Unit)? = null
 
     private lateinit var noteListContainer: LinearLayout
     private lateinit var emptyHintText: TextView
@@ -62,19 +80,22 @@ class MelodyTrainerActivity : BaseActivity() {
     private lateinit var addNoteButtonsRow: LinearLayout
     private lateinit var voiceCheckSwitch: CheckBox
     private lateinit var voiceStatusText: TextView
+    private lateinit var rhythmCheckSwitch: CheckBox
+    private lateinit var rhythmStatusText: TextView
 
     private val noteRowViews = mutableListOf<View>()
     private var highlightedRow = -1
 
+    private val rhythmEndRunnable = Runnable { finishRhythm() }
+
     private val micPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        if (granted) {
-            startVoiceSession()
-        } else {
-            setVoiceSwitchChecked(false)
-            voiceStatusText.text = getString(R.string.melody_trainer_mic_permission_required)
-        }
+        val grant = pendingMicGrant
+        val deny = pendingMicDeny
+        pendingMicGrant = null
+        pendingMicDeny = null
+        if (granted) grant?.invoke() else deny?.invoke()
     }
 
     private val playerListener = object : MelodySequencePlayer.Listener {
@@ -100,12 +121,15 @@ class MelodyTrainerActivity : BaseActivity() {
         addNoteButtonsRow = findViewById(R.id.add_note_buttons_row)
         voiceCheckSwitch = findViewById(R.id.voice_check_switch)
         voiceStatusText = findViewById(R.id.voice_status_text)
+        rhythmCheckSwitch = findViewById(R.id.rhythm_check_switch)
+        rhythmStatusText = findViewById(R.id.rhythm_status_text)
 
         buildAddNoteButtons()
         setupOctaveControls()
         setupTempoControl()
         setupTransport()
         setupVoiceCheck()
+        setupRhythmCheck()
 
         renderOctave()
         renderTempo()
@@ -171,9 +195,16 @@ class MelodyTrainerActivity : BaseActivity() {
         }
     }
 
+    private fun setupRhythmCheck() {
+        rhythmCheckSwitch.setOnCheckedChangeListener { _, checked ->
+            if (suppressRhythmSwitchCallback) return@setOnCheckedChangeListener
+            if (checked) requestRhythmSession() else stopRhythmSession(clearGreens = true)
+        }
+    }
+
     // region editing
 
-    private val isBusy: Boolean get() = isPlaybackActive || isVoiceActive
+    private val isBusy: Boolean get() = isPlaybackActive || isVoiceActive || isRhythmActive
 
     private fun addNote(phthong: TrainerPhthong) {
         if (isBusy) return
@@ -227,10 +258,35 @@ class MelodyTrainerActivity : BaseActivity() {
 
     // endregion
 
+    // region microphone permission
+
+    private fun ensureMicThen(onGranted: () -> Unit, onDenied: () -> Unit) {
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            onGranted()
+        } else {
+            pendingMicGrant = onGranted
+            pendingMicDeny = onDenied
+            micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+
+    private fun onPitchDetected(match: PitchMatch?) {
+        when {
+            isVoiceActive -> handleVoiceFrame(match)
+            isRhythmActive -> handleRhythmFrame(match)
+        }
+    }
+
+    // endregion
+
     // region Mode 2: voice check
 
     private fun requestVoiceSession() {
-        if (isPlaybackActive) {
+        if (isPlaybackActive || isRhythmActive) {
             setVoiceSwitchChecked(false)
             return
         }
@@ -239,15 +295,12 @@ class MelodyTrainerActivity : BaseActivity() {
             voiceStatusText.text = getString(R.string.melody_trainer_voice_need_notes)
             return
         }
-        val granted = ContextCompat.checkSelfPermission(
-            this,
-            Manifest.permission.RECORD_AUDIO
-        ) == PackageManager.PERMISSION_GRANTED
-        if (granted) {
-            startVoiceSession()
-        } else {
-            micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-        }
+        ensureMicThen(onGranted = ::startVoiceSession, onDenied = ::onVoiceMicDenied)
+    }
+
+    private fun onVoiceMicDenied() {
+        setVoiceSwitchChecked(false)
+        voiceStatusText.text = getString(R.string.melody_trainer_mic_permission_required)
     }
 
     private fun startVoiceSession() {
@@ -256,13 +309,13 @@ class MelodyTrainerActivity : BaseActivity() {
             return
         }
         matchedIndices.clear()
-        correctCount = 0
-        evaluator = PitchGreeningEvaluator(notes.map { it.phthong })
+        voiceCorrectCount = 0
+        voiceEvaluator = PitchGreeningEvaluator(notes.map { it.phthong })
         isVoiceActive = true
         renderNotes()
         if (!pitchEngine.start()) {
             isVoiceActive = false
-            evaluator = null
+            voiceEvaluator = null
             setVoiceSwitchChecked(false)
             voiceStatusText.text = getString(R.string.melody_trainer_mic_unavailable)
             renderNotes()
@@ -271,16 +324,15 @@ class MelodyTrainerActivity : BaseActivity() {
         updateVoiceStatus()
     }
 
-    private fun onPitchDetected(match: PitchMatch?) {
-        val activeEvaluator = evaluator ?: return
-        if (!isVoiceActive) return
-        val result = activeEvaluator.onFrame(match)
+    private fun handleVoiceFrame(match: PitchMatch?) {
+        val evaluator = voiceEvaluator ?: return
+        val result = evaluator.onFrame(match)
         if (result != null && result.matched) {
             matchedIndices.add(result.targetIndex)
-            correctCount++
+            voiceCorrectCount++
             colorRow(result.targetIndex, MATCHED_COLOR)
         }
-        if (activeEvaluator.isComplete) {
+        if (evaluator.isComplete) {
             finishVoiceSession()
         } else {
             updateVoiceStatus()
@@ -293,17 +345,17 @@ class MelodyTrainerActivity : BaseActivity() {
         setVoiceSwitchChecked(false)
         voiceStatusText.text = getString(
             R.string.melody_trainer_voice_done,
-            correctCount,
+            voiceCorrectCount,
             notes.size
         )
-        applyControlState()
+        renderNotes()
     }
 
     private fun stopVoiceSession(clearGreens: Boolean) {
         val wasActive = isVoiceActive
         pitchEngine.stop()
         isVoiceActive = false
-        evaluator = null
+        voiceEvaluator = null
         if (clearGreens) {
             matchedIndices.clear()
         }
@@ -314,7 +366,7 @@ class MelodyTrainerActivity : BaseActivity() {
     }
 
     private fun updateVoiceStatus() {
-        val target = evaluator?.currentTarget() ?: return
+        val target = voiceEvaluator?.currentTarget() ?: return
         voiceStatusText.text = getString(R.string.melody_trainer_voice_listening, target.displayName)
     }
 
@@ -322,6 +374,145 @@ class MelodyTrainerActivity : BaseActivity() {
         suppressVoiceSwitchCallback = true
         voiceCheckSwitch.isChecked = checked
         suppressVoiceSwitchCallback = false
+    }
+
+    // endregion
+
+    // region Mode 3: rhythm timing
+
+    private fun requestRhythmSession() {
+        if (isPlaybackActive || isVoiceActive) {
+            setRhythmSwitchChecked(false)
+            return
+        }
+        if (notes.isEmpty()) {
+            setRhythmSwitchChecked(false)
+            rhythmStatusText.text = getString(R.string.melody_trainer_voice_need_notes)
+            return
+        }
+        ensureMicThen(onGranted = ::startRhythmCountdown, onDenied = ::onRhythmMicDenied)
+    }
+
+    private fun onRhythmMicDenied() {
+        setRhythmSwitchChecked(false)
+        rhythmStatusText.text = getString(R.string.melody_trainer_mic_permission_required)
+    }
+
+    private fun startRhythmCountdown() {
+        if (notes.isEmpty()) {
+            setRhythmSwitchChecked(false)
+            return
+        }
+        matchedIndices.clear()
+        rhythmCorrectCount = 0
+        rhythmStartMillis = -1L
+        isRhythmActive = true
+        renderNotes()
+        countdownRemaining = RhythmTimingEvaluator.COUNTDOWN_SECONDS
+        runCountdownTick()
+    }
+
+    private fun runCountdownTick() {
+        if (!isRhythmActive) return
+        if (countdownRemaining > 0) {
+            rhythmStatusText.text = getString(R.string.melody_trainer_rhythm_countdown, countdownRemaining)
+            countdownRemaining--
+            uiHandler.postDelayed({ runCountdownTick() }, COUNTDOWN_TICK_MILLIS)
+        } else {
+            rhythmStatusText.text = getString(R.string.melody_trainer_rhythm_go)
+            startRhythmClock()
+        }
+    }
+
+    private fun startRhythmClock() {
+        rhythmPlan = MelodyPlaybackPlanner.plan(MelodySequence(notes.toList()), MelodyTempo.of(bpm))
+        if (rhythmPlan.isEmpty()) {
+            stopRhythmSession(clearGreens = true)
+            return
+        }
+        rhythmEvaluator = RhythmTimingEvaluator(rhythmPlan)
+        rhythmTotalMillis = MelodyPlaybackPlanner.totalDurationMillis(rhythmPlan)
+        if (!pitchEngine.start()) {
+            rhythmStatusText.text = getString(R.string.melody_trainer_mic_unavailable)
+            stopRhythmSession(clearGreens = false)
+            return
+        }
+        rhythmStartMillis = SystemClock.elapsedRealtime()
+        uiHandler.postDelayed(rhythmEndRunnable, rhythmTotalMillis + RHYTHM_END_GRACE_MILLIS)
+    }
+
+    private fun handleRhythmFrame(match: PitchMatch?) {
+        val evaluator = rhythmEvaluator ?: return
+        if (rhythmStartMillis < 0L) return
+        val elapsed = SystemClock.elapsedRealtime() - rhythmStartMillis
+
+        val verdict = evaluator.onFrame(elapsed, voicedNow = match != null)
+        if (verdict != null && verdict.matched) {
+            matchedIndices.add(verdict.noteIndex)
+            rhythmCorrectCount++
+            colorRow(verdict.noteIndex, MATCHED_COLOR)
+        }
+
+        val active = evaluator.activeNoteIndex(elapsed)
+        if (active in notes.indices && !matchedIndices.contains(active)) {
+            highlightRow(active)
+            rhythmStatusText.text = getString(
+                R.string.melody_trainer_rhythm_running,
+                phthongDisplay(notes[active])
+            )
+        } else {
+            clearHighlight()
+        }
+
+        if (elapsed >= rhythmTotalMillis) {
+            finishRhythm()
+        }
+    }
+
+    private fun finishRhythm() {
+        if (!isRhythmActive) return
+        uiHandler.removeCallbacks(rhythmEndRunnable)
+        val elapsed = if (rhythmStartMillis >= 0L) SystemClock.elapsedRealtime() - rhythmStartMillis else 0L
+        val verdict = rhythmEvaluator?.finish(elapsed)
+        if (verdict != null && verdict.matched) {
+            matchedIndices.add(verdict.noteIndex)
+            rhythmCorrectCount++
+        }
+        pitchEngine.stop()
+        isRhythmActive = false
+        rhythmStartMillis = -1L
+        rhythmEvaluator = null
+        clearHighlight()
+        setRhythmSwitchChecked(false)
+        rhythmStatusText.text = getString(
+            R.string.melody_trainer_rhythm_done,
+            rhythmCorrectCount,
+            notes.size
+        )
+        renderNotes()
+    }
+
+    private fun stopRhythmSession(clearGreens: Boolean) {
+        val wasActive = isRhythmActive
+        uiHandler.removeCallbacksAndMessages(null)
+        pitchEngine.stop()
+        isRhythmActive = false
+        rhythmStartMillis = -1L
+        rhythmEvaluator = null
+        if (clearGreens) {
+            matchedIndices.clear()
+        }
+        clearHighlight()
+        if (wasActive) {
+            rhythmStatusText.text = getString(R.string.melody_trainer_rhythm_hint)
+        }
+        renderNotes()
+    }
+
+    private fun setRhythmSwitchChecked(checked: Boolean) {
+        suppressRhythmSwitchCallback = true
+        rhythmCheckSwitch.isChecked = checked
+        suppressRhythmSwitchCallback = false
     }
 
     // endregion
@@ -436,12 +627,14 @@ class MelodyTrainerActivity : BaseActivity() {
     }
 
     private fun highlightRow(index: Int) {
+        if (index == highlightedRow) return
         clearHighlight()
         noteRowViews.getOrNull(index)?.setBackgroundColor(HIGHLIGHT_COLOR)
         highlightedRow = index
     }
 
     private fun clearHighlight() {
+        if (highlightedRow < 0) return
         val restore = if (matchedIndices.contains(highlightedRow)) MATCHED_COLOR else Color.TRANSPARENT
         noteRowViews.getOrNull(highlightedRow)?.setBackgroundColor(restore)
         highlightedRow = -1
@@ -456,7 +649,8 @@ class MelodyTrainerActivity : BaseActivity() {
         playButton.isEnabled = !isBusy && notes.isNotEmpty()
         clearButton.isEnabled = !isBusy && notes.isNotEmpty()
         tempoSeek.isEnabled = !isBusy
-        voiceCheckSwitch.isEnabled = !isPlaybackActive
+        voiceCheckSwitch.isEnabled = !isPlaybackActive && !isRhythmActive
+        rhythmCheckSwitch.isEnabled = !isPlaybackActive && !isVoiceActive
         for (button in addNoteButtonsRow.children) {
             button.isEnabled = !isBusy
         }
@@ -504,10 +698,15 @@ class MelodyTrainerActivity : BaseActivity() {
             setVoiceSwitchChecked(false)
             stopVoiceSession(clearGreens = false)
         }
+        if (isRhythmActive) {
+            setRhythmSwitchChecked(false)
+            stopRhythmSession(clearGreens = false)
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
+        uiHandler.removeCallbacksAndMessages(null)
         player.stop()
         tonePlayer.release()
         pitchEngine.stop()
@@ -520,7 +719,9 @@ class MelodyTrainerActivity : BaseActivity() {
         const val MIN_DURATION = 0.5f
         const val MAX_DURATION = 4.0f
         const val GORGO_BEATS = 0.5f
-        const val HIGHLIGHT_COLOR = 0x33FFC107 // translucent amber: note currently playing
-        const val MATCHED_COLOR = 0x6600C853 // green: phthong sung correctly
+        const val COUNTDOWN_TICK_MILLIS = 1_000L
+        const val RHYTHM_END_GRACE_MILLIS = 1_500L
+        const val HIGHLIGHT_COLOR = 0x33FFC107 // translucent amber: note currently active
+        const val MATCHED_COLOR = 0x6600C853 // green: phthong sung / timed correctly
     }
 }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluator.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluator.kt
@@ -52,10 +52,13 @@ class RhythmTimingEvaluator(
             verdict = finalizeSegment(segmentStart, elapsedMillis, segmentNote)
             clearSegment()
         } else if (voicedNow && voiced && segmentNote >= 0) {
-            // Still singing: if we have crossed past the current note's scheduled window,
-            // close it at the boundary and continue the legato line into the next note.
+            // Still singing and crossed past the current note's scheduled window: close it at
+            // the boundary and continue the legato line into the next note — but only when
+            // there IS a next note. The final note is left open until the real release (or the
+            // safety cutoff) so an over-held last note is judged on its true offset, not closed
+            // as correct at its scheduled end.
             val note = plan[segmentNote]
-            if (elapsedMillis >= note.endMillis) {
+            if (elapsedMillis >= note.endMillis && segmentNote < plan.lastIndex) {
                 verdict = finalizeSegment(segmentStart, note.endMillis, segmentNote)
                 startSegment(note.endMillis)
             }
@@ -101,14 +104,24 @@ class RhythmTimingEvaluator(
      *  3. otherwise (the onset precedes every remaining note) the earliest not-yet-judged note.
      */
     private fun chooseNote(onsetMillis: Long): Int {
+        // 1. the NEAREST not-yet-judged note whose start is within onset tolerance (when two
+        //    close notes are both eligible, the closer start wins, not just the earlier one).
+        var nearest = -1
+        var nearestDistance = Long.MAX_VALUE
         for (index in plan.indices) {
-            if (!judged[index] && abs(onsetMillis - plan[index].startMillis) <= onsetToleranceMillis) {
-                return index
+            if (judged[index]) continue
+            val distance = abs(onsetMillis - plan[index].startMillis)
+            if (distance <= onsetToleranceMillis && distance < nearestDistance) {
+                nearestDistance = distance
+                nearest = index
             }
         }
+        if (nearest >= 0) return nearest
+        // 2. otherwise (not near any start: late/sloppy) the earliest already-started one.
         for (index in plan.indices) {
             if (!judged[index] && plan[index].startMillis <= onsetMillis) return index
         }
+        // 3. otherwise (precedes every remaining note) the earliest not-yet-judged note.
         for (index in plan.indices) {
             if (!judged[index]) return index
         }

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluator.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluator.kt
@@ -1,0 +1,107 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import kotlin.math.abs
+
+/** Timing verdict for one target note in the rhythm exercise. */
+data class RhythmVerdict(
+    val noteIndex: Int,
+    val matched: Boolean,
+    /** Signed onset error in ms: positive = the singer started late, negative = early. */
+    val onsetErrorMillis: Long,
+    /** Signed duration error in ms: positive = held too long, negative = too short. */
+    val durationErrorMillis: Long
+)
+
+/**
+ * Streaming evaluator for the rhythm-timing ("άσκηση χρόνου") mode. After the countdown,
+ * it is fed one frame per analysis window — `(elapsedMillis since the clock started,
+ * voiced)` — and detects sung segments from the voiced↔silent transitions. Each completed
+ * segment is assigned to the nearest not-yet-judged scheduled note (by onset time) from the
+ * [MelodyPlaybackPlanner] schedule, so a skipped note is simply left un-green rather than
+ * dragging every later note out of alignment. A note turns green only when the singer
+ * started near its scheduled time and held it for roughly its scheduled duration. Pure
+ * logic, fully unit-testable.
+ */
+class RhythmTimingEvaluator(
+    private val plan: List<PlannedNoteEvent>,
+    private val onsetToleranceMillis: Long = DEFAULT_ONSET_TOLERANCE_MILLIS,
+    private val durationToleranceRatio: Double = DEFAULT_DURATION_TOLERANCE_RATIO,
+    private val minDurationToleranceMillis: Long = DEFAULT_MIN_DURATION_TOLERANCE_MILLIS
+) {
+    private val judged = BooleanArray(plan.size)
+    private var judgedCount = 0
+    private var voiced = false
+    private var segmentStart = -1L
+
+    val isComplete: Boolean get() = judgedCount >= plan.size
+
+    /** Index of the note whose scheduled window contains [elapsedMillis], or -1. */
+    fun activeNoteIndex(elapsedMillis: Long): Int =
+        plan.indexOfFirst { elapsedMillis >= it.startMillis && elapsedMillis < it.endMillis }
+
+    fun onFrame(elapsedMillis: Long, voicedNow: Boolean): RhythmVerdict? {
+        var verdict: RhythmVerdict? = null
+        if (voicedNow && !voiced) {
+            segmentStart = elapsedMillis
+        } else if (!voicedNow && voiced) {
+            verdict = closeSegment(elapsedMillis)
+        }
+        voiced = voicedNow
+        return verdict
+    }
+
+    /** Closes a still-open sung segment when the exercise ends while voiced. */
+    fun finish(elapsedMillis: Long): RhythmVerdict? {
+        val verdict = if (voiced) closeSegment(elapsedMillis) else null
+        voiced = false
+        return verdict
+    }
+
+    private fun closeSegment(offsetMillis: Long): RhythmVerdict? {
+        val onset = segmentStart
+        segmentStart = -1L
+        if (onset < 0L) return null
+
+        val target = nearestUnjudged(onset) ?: return null
+        judged[target] = true
+        judgedCount++
+
+        val note = plan[target]
+        val onsetError = onset - note.startMillis
+        val durationError = (offsetMillis - onset) - note.durationMillis
+        val durationAllowance = maxOf(
+            minDurationToleranceMillis,
+            (note.durationMillis * durationToleranceRatio).toLong()
+        )
+        val matched = abs(onsetError) <= onsetToleranceMillis && abs(durationError) <= durationAllowance
+        return RhythmVerdict(target, matched, onsetError, durationError)
+    }
+
+    private fun nearestUnjudged(onsetMillis: Long): Int? {
+        var best = -1
+        var bestDistance = Long.MAX_VALUE
+        for (index in plan.indices) {
+            if (judged[index]) continue
+            val distance = abs(onsetMillis - plan[index].startMillis)
+            if (distance < bestDistance) {
+                bestDistance = distance
+                best = index
+            }
+        }
+        return if (best >= 0) best else null
+    }
+
+    fun reset() {
+        judged.fill(false)
+        judgedCount = 0
+        voiced = false
+        segmentStart = -1L
+    }
+
+    companion object {
+        const val DEFAULT_ONSET_TOLERANCE_MILLIS = 250L
+        const val DEFAULT_DURATION_TOLERANCE_RATIO = 0.5
+        const val DEFAULT_MIN_DURATION_TOLERANCE_MILLIS = 150L
+        const val COUNTDOWN_SECONDS = 5
+    }
+}

--- a/app/src/main/res/layout/layout_melody_trainer.xml
+++ b/app/src/main/res/layout/layout_melody_trainer.xml
@@ -231,5 +231,29 @@
             android:layout_marginTop="6dp"
             android:text="@string/melody_trainer_voice_hint"
             android:textSize="15sp" />
+
+        <!-- Timing exercise (Mode 3): 5s countdown then green notes said on time -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="#33888888" />
+
+        <CheckBox
+            android:id="@+id/rhythm_check_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/melody_trainer_rhythm_check"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/rhythm_status_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/melody_trainer_rhythm_hint"
+            android:textSize="15sp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -724,4 +724,10 @@ Imagine the phthongs placed on a ladder as shown below:</string>
     <string name="melody_trainer_voice_need_notes">Add some phthongi first to use voice check.</string>
     <string name="melody_trainer_mic_permission_required">Microphone permission is required for voice check.</string>
     <string name="melody_trainer_mic_unavailable">The microphone is not available right now.</string>
+    <string name="melody_trainer_rhythm_check">Timing exercise</string>
+    <string name="melody_trainer_rhythm_hint">Turn on the timing exercise: after a 5-second countdown, say each phthong on time for it to turn green.</string>
+    <string name="melody_trainer_rhythm_countdown">Get ready… %1$d</string>
+    <string name="melody_trainer_rhythm_go">Go!</string>
+    <string name="melody_trainer_rhythm_running">Say: %1$s</string>
+    <string name="melody_trainer_rhythm_done">Done! Correct timing: %1$d/%2$d</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -715,4 +715,10 @@
     <string name="melody_trainer_voice_need_notes">Πρόσθεσε πρώτα φθόγγους για να χρησιμοποιήσεις τον φωνητικό έλεγχο.</string>
     <string name="melody_trainer_mic_permission_required">Χρειάζεται άδεια μικροφώνου για τον φωνητικό έλεγχο.</string>
     <string name="melody_trainer_mic_unavailable">Το μικρόφωνο δεν είναι διαθέσιμο αυτή τη στιγμή.</string>
+    <string name="melody_trainer_rhythm_check">Άσκηση χρόνου</string>
+    <string name="melody_trainer_rhythm_hint">Άναψε την άσκηση χρόνου: μετά από αντίστροφη μέτρηση 5 δευτ. πες κάθε φθόγγο στον σωστό χρόνο για να πρασινίσει.</string>
+    <string name="melody_trainer_rhythm_countdown">Ετοιμάσου… %1$d</string>
+    <string name="melody_trainer_rhythm_go">Ξεκίνα!</string>
+    <string name="melody_trainer_rhythm_running">Πες: %1$s</string>
+    <string name="melody_trainer_rhythm_done">Ολοκληρώθηκε! Σωστός χρόνος: %1$d/%2$d</string>
 </resources>

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluatorTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluatorTest.kt
@@ -1,0 +1,89 @@
+package com.johnchourp.learnbyzantinemusic.trainer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RhythmTimingEvaluatorTest {
+
+    // Two notes, 1 beat each at 60 bpm -> note0 [0,1000), note1 [1000,2000).
+    private fun twoNotePlan(): List<PlannedNoteEvent> {
+        val sequence = MelodySequence(
+            listOf(TrainerNote(TrainerPhthong.NI), TrainerNote(TrainerPhthong.PA))
+        )
+        return MelodyPlaybackPlanner.plan(sequence, MelodyTempo(60))
+    }
+
+    /** Simulates a voiced sung segment from [onset] to [offset]; returns the verdict. */
+    private fun RhythmTimingEvaluator.singSegment(onset: Long, offset: Long): RhythmVerdict? {
+        onFrame(onset, true)
+        return onFrame(offset, false)
+    }
+
+    @Test
+    fun `notes sung on time turn matched`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        val first = evaluator.singSegment(0, 975)
+        assertEquals(0, first?.noteIndex)
+        assertTrue(first!!.matched)
+
+        val second = evaluator.singSegment(1000, 1975)
+        assertEquals(1, second?.noteIndex)
+        assertTrue(second!!.matched)
+        assertTrue(evaluator.isComplete)
+    }
+
+    @Test
+    fun `a late onset is not matched`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        val verdict = evaluator.singSegment(400, 1200) // note0 starts at 0; 400 ms late > 250
+        assertEquals(0, verdict?.noteIndex)
+        assertFalse(verdict!!.matched)
+    }
+
+    @Test
+    fun `too-short duration is not matched even with a good onset`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        val verdict = evaluator.singSegment(0, 200) // held 200 ms vs 1000 ms expected
+        assertEquals(0, verdict?.noteIndex)
+        assertFalse(verdict!!.matched)
+    }
+
+    @Test
+    fun `a skipped note is passed over and the next is evaluated`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        // Singer ignores note0 entirely and sings note1 on time.
+        val verdict = evaluator.singSegment(1000, 1975)
+        assertEquals(1, verdict?.noteIndex)
+        assertTrue(verdict!!.matched)
+        // note0 was never sung, so it stays unjudged (and ungreened).
+        assertFalse(evaluator.isComplete)
+    }
+
+    @Test
+    fun `finish closes a segment still voiced at the end`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        evaluator.onFrame(0, true)
+        val verdict = evaluator.finish(1000)
+        assertEquals(0, verdict?.noteIndex)
+        assertTrue(verdict!!.matched)
+    }
+
+    @Test
+    fun `active note index tracks the schedule`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        assertEquals(0, evaluator.activeNoteIndex(500))
+        assertEquals(1, evaluator.activeNoteIndex(1500))
+        assertEquals(-1, evaluator.activeNoteIndex(5000))
+    }
+
+    @Test
+    fun `silence alone yields no verdict`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan())
+        assertNull(evaluator.onFrame(100, false))
+        assertNull(evaluator.onFrame(200, false))
+        assertFalse(evaluator.isComplete)
+    }
+}

--- a/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluatorTest.kt
+++ b/app/src/test/java/com/johnchourp/learnbyzantinemusic/trainer/RhythmTimingEvaluatorTest.kt
@@ -142,4 +142,25 @@ class RhythmTimingEvaluatorTest {
         assertEquals(1, second?.noteIndex)
         assertTrue(second!!.matched)
     }
+
+    @Test
+    fun `the final note is left open past its scheduled end while still held`() {
+        val evaluator = RhythmTimingEvaluator(twoNotePlan()) // note0 [0,1000), note1 [1000,2000)
+        evaluator.singSegment(0, 980) // note0 on time
+
+        // Hold note1 continuously well past its scheduled end (2000) without releasing.
+        val verdicts = mutableListOf<RhythmVerdict>()
+        var t = 1000L
+        while (t <= 2400) {
+            evaluator.onFrame(t, true)?.let { verdicts.add(it) }
+            t += 50
+        }
+        // It must NOT be closed/greened at the 2000 ms boundary — no verdict yet.
+        assertTrue(verdicts.isEmpty())
+
+        // Only when the safety cutoff fires (still held) is it judged — and not matched.
+        val verdict = evaluator.finish(3500)
+        assertEquals(1, verdict?.noteIndex)
+        assertFalse(verdict!!.matched)
+    }
 }


### PR DESCRIPTION
## Melody Trainer — timing exercise (Mode 3)

Implements the rhythm-timing part of ClickUp task [869dbkkwc](https://app.clickup.com/t/90121749478/869dbkkwc). Stacks on #50.

Adds the **Άσκηση χρόνου** toggle. When enabled it runs a **5-second countdown**, then starts the χρόνος clock: the user says each phthong and the notes said in the **right time** turn green. The currently-due note is highlighted as the clock advances so the singer knows what to sing and when.

### Core (pure, no Android deps, unit-tested)
- `RhythmTimingEvaluator` — streaming state machine fed `(elapsedMillis, voiced)` frames. It segments the sung stream by voiced↔silent transitions and assigns each segment to the **nearest not-yet-judged scheduled note** (by onset) from the `MelodyPlaybackPlanner` timeline, so a skipped note is simply left un-green instead of dragging later notes out of alignment. A note matches when its onset is within tolerance of the scheduled start **and** its held duration is within tolerance of the scheduled duration.

### Android glue
- `MelodyTrainerActivity` — timing-exercise toggle with mic-permission flow (shared with voice check), a `Handler`-driven 5 s countdown, the elapsed-time clock fed by the existing `TrainerPitchEngine` frames (voiced = pitch present), live active-note highlighting, row greening, a safety end-timeout, and mutual exclusion with the playback and voice-check modes.

### Tests
7 new unit tests for the timing evaluator; **81 unit tests total, all green**. `assembleDebug` + `check-no-secrets.sh` pass.

**PR 3 of 3.** Base is `feat/melody-trainer-pitch` (#50); review the incremental diff here.

> Note: the microphone/timing behaviour is verified on a real device via `$learn-byzantine-live-fix-loop` before the production release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
