### PR TITLE
fix(a11y): enforce 48dp touch target on octave-strip chips

### DIFF
--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/lessons/ui/PhthongsNamesScreen.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/lessons/ui/PhthongsNamesScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -230,11 +231,13 @@ private fun OctaveChip(@StringRes nameRes: Int, selected: Boolean, onClick: () -
     )
     Box(
         modifier = Modifier
+            .heightIn(min = 48.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(container)
             .border(1.dp, if (selected) LbmBrown else LbmOutline, RoundedCornerShape(12.dp))
             .selectable(selected = selected, role = Role.Button, onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 10.dp),
+        contentAlignment = Alignment.Center,
     ) {
         Text(
             text = stringResource(nameRes),


### PR DESCRIPTION
## Summary
On the «Ονόματα Φθόγγων» page, `OctaveChip` (the tappable octave-strip phthongs) built its tap target from a bare `Box` using `androidx.compose.foundation.selection.selectable(...)` + `.padding(horizontal = 14.dp, vertical = 10.dp)` around a single-line `titleMedium` Text (lineHeight 22.sp). The foundation `selectable` modifier does **not** apply `minimumInteractiveComponentSize` (only Material3 component wrappers enforce the 48dp floor), so the chip computed to ~42dp tall — **below the 48dp WCAG/Material minimum**.

## Fix
- Add `.heightIn(min = 48.dp)` to the `OctaveChip` Box modifier and center the label (`contentAlignment = Alignment.Center`) so the text stays vertically centered in the taller chip.

This mirrors the same fix already applied to the duotrioquatro `SelectorChip` in v1.4.0. Pure UI/a11y change — no behavior change beyond the touch-target height.

## Testing
`./gradlew testDebugUnitTest assembleDebug` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)