### PR TITLE
fix(modes): opt in to ExperimentalLayoutApi so the v1.10.0 release build compiles

### DIFF
--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/modes/ui/EightModesScreen.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/modes/ui/EightModesScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -213,6 +214,7 @@ fun EightModesScreen(
 
 /* ----------------------------- Genus legend ----------------------------- */
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun GenusLegend(currentGenus: ModeScaleGenus) {
     LessonCard(title = stringResource(R.string.eight_modes_genus_legend_title)) {


### PR DESCRIPTION
## Why
The `v1.10.0` tag release (run 28296335571) **failed** at `:app:compileReleaseKotlin`:

```
e: EightModesScreen.kt:219:9 The API of this layout is experimental and is likely to change in the future.
> Task :app:compileReleaseKotlin FAILED
```

The 8 Ήχοι genus legend uses `FlowRow`, which is `@ExperimentalLayoutApi`. `compileDebugKotlin` only **warns** about the missing opt-in, but the **release** compile treats it as an **error** — so `assembleDebug`, the local unit tests, the pre-PR review and the Codex review (all debug-only) passed, while the tag release build broke.

## Fix
Add `@OptIn(ExperimentalLayoutApi::class)` to `GenusLegend` — a no-op annotation, zero behaviour change.

## Verification
Reproduced the failure locally, then verified the fix with a full **release** build: `./gradlew :app:assembleRelease` (runs `compileReleaseKotlin` + R8/minify + `lintVitalRelease`, unsigned locally) succeeded, plus `compileDebugKotlin` + `testDebugUnitTest`. `check-no-secrets.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)