### PR TITLE
feat(notes): redesign «Οι Σημειώσεις Μου» (My Notes) in Compose + Material3 + animations (v1.14.0)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.johnchourp.learnbyzantinemusic"
         minSdk = 24
         targetSdk = 34
-        versionCode = 50
-        versionName = "1.13.0"
+        versionCode = 51
+        versionName = "1.14.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesActivity.kt
@@ -7,12 +7,12 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.activity.compose.setContent
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.johnchourp.learnbyzantinemusic.BaseActivity
 import com.johnchourp.learnbyzantinemusic.R
 import com.johnchourp.learnbyzantinemusic.notes.ui.NotesScreen
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmTheme
 
 class NotesActivity : BaseActivity() {
     private lateinit var notesPrefs: NotesPrefs
@@ -69,13 +69,14 @@ class NotesActivity : BaseActivity() {
         ensureBackupFolderConfigured()
 
         setContent {
-            MaterialTheme {
+            LbmTheme {
                 val uiState by viewModel.uiState.collectAsStateWithLifecycle()
                 val statusText = resolveStatusText(uiState.statusMessage)
 
                 NotesScreen(
                     uiState = uiState,
                     statusText = statusText,
+                    onBack = { finish() },
                     onCreateNote = { viewModel.createNewNote() },
                     onDeleteSelected = { viewModel.deleteSelectedNote() },
                     onSaveNow = { viewModel.saveNow() },

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.activity.compose.setContent
@@ -66,6 +67,19 @@ class NotesActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         notesPrefs = NotesPrefs(this)
 
+        // Flush unsaved editor edits on the way out (header Back button and system back both route
+        // through here), so edits made within the 1.2s auto-save debounce aren't lost. Scoped to a
+        // real exit — NOT onStop — so it never fires while a SAF picker (folder/import) is open.
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    viewModel.flushPendingEdits()
+                    finish()
+                }
+            }
+        )
+
         ensureBackupFolderConfigured()
 
         setContent {
@@ -76,7 +90,7 @@ class NotesActivity : BaseActivity() {
                 NotesScreen(
                     uiState = uiState,
                     statusText = statusText,
-                    onBack = { finish() },
+                    onBack = { onBackPressedDispatcher.onBackPressed() },
                     onCreateNote = { viewModel.createNewNote() },
                     onDeleteSelected = { viewModel.deleteSelectedNote() },
                     onSaveNow = { viewModel.saveNow() },
@@ -93,13 +107,6 @@ class NotesActivity : BaseActivity() {
                 )
             }
         }
-    }
-
-    override fun onStop() {
-        // Persist any unsaved editor edits before the screen goes away (Back button, Home, app switch),
-        // since the 1.2s auto-save debounce may not have fired yet.
-        viewModel.flushPendingEdits()
-        super.onStop()
     }
 
     private fun ensureBackupFolderConfigured() {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesActivity.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesActivity.kt
@@ -95,6 +95,13 @@ class NotesActivity : BaseActivity() {
         }
     }
 
+    override fun onStop() {
+        // Persist any unsaved editor edits before the screen goes away (Back button, Home, app switch),
+        // since the 1.2s auto-save debounce may not have fired yet.
+        viewModel.flushPendingEdits()
+        super.onStop()
+    }
+
     private fun ensureBackupFolderConfigured() {
         val storedUri = notesPrefs.getFolderUri()
         if (storedUri != null && notesPrefs.hasPersistedReadWriteAccess(contentResolver, storedUri)) {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesViewModel.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesViewModel.kt
@@ -4,8 +4,11 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -132,6 +135,31 @@ class NotesViewModel(
         autoSaveNow(SaveTrigger.MANUAL)
     }
 
+    /**
+     * Persist any unsaved editor edits on a process-lifetime scope so they survive the host
+     * Activity/ViewModel being torn down — e.g. the user taps the header Back button (or backgrounds
+     * the app) within the auto-save debounce window, which would otherwise cancel [viewModelScope]
+     * before the pending save reaches the repository. Idempotent and a no-op when nothing is dirty.
+     */
+    fun flushPendingEdits() {
+        val current = _uiState.value
+        val selectedId = current.selectedNoteId ?: return
+        if (!current.canInteractWithNotes) {
+            return
+        }
+        if (current.editorTitle == lastPersistedTitle && current.editorBody == lastPersistedBody) {
+            return
+        }
+        autoSaveJob?.cancel()
+        val title = current.editorTitle
+        val body = current.editorBody
+        lastPersistedTitle = title.trim()
+        lastPersistedBody = body.trimEnd()
+        flushScope.launch {
+            repository.saveNote(noteId = selectedId, title = title, body = body)
+        }
+    }
+
     fun exportNow() {
         viewModelScope.launch {
             _uiState.update { it.copy(isSaving = true) }
@@ -233,6 +261,10 @@ class NotesViewModel(
 
     companion object {
         private const val AUTO_SAVE_DELAY_MS = 1200L
+
+        // Process-lifetime scope for exit-time flushes; outlives any single Activity/ViewModel so a
+        // save triggered on the way out (Back/background) completes instead of being cancelled.
+        private val flushScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 }
 

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesViewModel.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/NotesViewModel.kt
@@ -137,9 +137,10 @@ class NotesViewModel(
 
     /**
      * Persist any unsaved editor edits on a process-lifetime scope so they survive the host
-     * Activity/ViewModel being torn down — e.g. the user taps the header Back button (or backgrounds
-     * the app) within the auto-save debounce window, which would otherwise cancel [viewModelScope]
-     * before the pending save reaches the repository. Idempotent and a no-op when nothing is dirty.
+     * Activity/ViewModel being torn down — e.g. the user taps Back within the auto-save debounce
+     * window, which would otherwise cancel [viewModelScope] before the pending save reaches the
+     * repository. Invoked only from the real back-exit path (never while a SAF picker is open, so it
+     * cannot race an import). Idempotent and a no-op when nothing is dirty.
      */
     fun flushPendingEdits() {
         val current = _uiState.value

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -248,7 +247,9 @@ fun NotesScreen(
                 )
             }
         } else {
-            items(uiState.notes, key = { it.id }) { note ->
+            // Prefix note keys so a note id from an imported backup can never collide with the
+            // static section keys ("hero", "editor", …) sharing this LazyColumn.
+            items(uiState.notes, key = { "note:${it.id}" }) { note ->
                 NoteRow(
                     note = note,
                     selected = uiState.selectedNoteId == note.id,
@@ -596,10 +597,11 @@ private fun EditorCard(
             onValueChange = onBodyChanged,
             enabled = enabled,
             label = { Text(text = stringResource(id = R.string.notes_editor_body_label)) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = 200.dp),
+            modifier = Modifier.fillMaxWidth(),
+            // Bounded so a long note scrolls inside the field instead of expanding the whole
+            // LazyColumn (and pushing the search/list far below the fold).
             minLines = 8,
+            maxLines = 14,
         )
 
         AnimatedVisibility(visible = enabled && !hasSelectedNote) {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
@@ -1,52 +1,121 @@
 package com.johnchourp.learnbyzantinemusic.notes.ui
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.johnchourp.learnbyzantinemusic.R
 import com.johnchourp.learnbyzantinemusic.notes.NoteEntity
 import com.johnchourp.learnbyzantinemusic.notes.NotesUiState
+import com.johnchourp.learnbyzantinemusic.ui.components.LessonCard
+import com.johnchourp.learnbyzantinemusic.ui.components.LessonHero
+import com.johnchourp.learnbyzantinemusic.ui.components.StaggeredAppear
+import com.johnchourp.learnbyzantinemusic.ui.theme.AccentCrimsonContainer
+import com.johnchourp.learnbyzantinemusic.ui.theme.AccentCrimsonContent
+import com.johnchourp.learnbyzantinemusic.ui.theme.AccentGoldContainer
+import com.johnchourp.learnbyzantinemusic.ui.theme.AccentGoldContent
+import com.johnchourp.learnbyzantinemusic.ui.theme.AccentGreenContainer
+import com.johnchourp.learnbyzantinemusic.ui.theme.AccentGreenContent
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmBrown
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmOutline
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmPageBg
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmPrimaryContainer
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmSurface
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmSurfaceVariant
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmTextPrimary
+import com.johnchourp.learnbyzantinemusic.ui.theme.LbmTextSecondary
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+
+/**
+ * Redesigned «Οι Σημειώσεις Μου» screen. A pure renderer of [NotesUiState] + callbacks built on the
+ * shared design system (hero, [StaggeredAppear] + [LessonCard] sections, branded palette) with a
+ * phone-first single-column layout, animated status/selection feedback and clear, icon-led actions.
+ * All persistence, backup and SAF logic stays in [com.johnchourp.learnbyzantinemusic.notes.NotesViewModel] /
+ * the host Activity — this only changes rendering.
+ */
+
+// The editor card's fixed position in the LazyColumn (hero=0, backup=1, stats+status=2, editor=3),
+// so tapping a note can smoothly scroll to it. Stays constant because no item above is conditional.
+private const val EDITOR_ITEM_INDEX = 3
 
 @Composable
 fun NotesScreen(
     uiState: NotesUiState,
     statusText: String,
+    onBack: () -> Unit,
     onCreateNote: () -> Unit,
     onDeleteSelected: () -> Unit,
     onSaveNow: () -> Unit,
@@ -60,106 +129,143 @@ fun NotesScreen(
     onEditorBodyChanged: (String) -> Unit
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
+    val listState = rememberLazyListState()
+    var scrollToEditorSignal by remember { mutableIntStateOf(0) }
 
-    Box(
+    LaunchedEffect(scrollToEditorSignal) {
+        if (scrollToEditorSignal > 0) {
+            listState.animateScrollToItem(EDITOR_ITEM_INDEX)
+        }
+    }
+
+    val enabled = uiState.canInteractWithNotes
+
+    LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                brush = Brush.verticalGradient(
-                    colors = listOf(
-                        Color(0xFFF4F7FF),
-                        Color(0xFFFDF7EE)
-                    )
-                )
-            )
-            .padding(12.dp)
+            .background(LbmPageBg),
+        contentPadding = PaddingValues(bottom = 28.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            HeroHeader(
-                folderName = uiState.folderName,
-                pendingSyncCount = uiState.pendingSyncCount,
-                lastSyncEpochMs = uiState.lastSyncEpochMs,
-                lastSyncError = uiState.lastSyncError
-            )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            StatsStrip(
-                notesCount = uiState.notesCount,
-                pendingSyncCount = uiState.pendingSyncCount,
-                isSaving = uiState.isSaving
-            )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            if (!statusText.isBlank()) {
-                Card(
-                    shape = RoundedCornerShape(16.dp),
-                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF4E5)),
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(
-                        text = statusText,
-                        modifier = Modifier.padding(12.dp),
-                        style = MaterialTheme.typography.bodyMedium
+        item(key = "hero") {
+            Column {
+                LessonHero(
+                    title = stringResource(R.string.notes_page_title),
+                    subtitle = stringResource(R.string.notes_page_subtitle),
+                    onBack = onBack,
+                    icon = Icons.Filled.Description,
+                )
+                AnimatedVisibility(visible = uiState.isSaving) {
+                    LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = LbmBrown,
+                        trackColor = LbmSurfaceVariant,
                     )
                 }
-                Spacer(modifier = Modifier.height(10.dp))
             }
+        }
 
-            ActionBar(
-                enabled = uiState.canInteractWithNotes,
-                onCreateNote = onCreateNote,
-                onDeleteSelected = { showDeleteDialog = true },
-                onSaveNow = onSaveNow,
-                onExportNow = onExportNow,
-                onImport = onImport,
-                onSelectFolder = onSelectFolder,
-                onResyncPending = onResyncPending
-            )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            OutlinedTextField(
-                value = uiState.searchQuery,
-                onValueChange = onSearchQueryChanged,
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text(text = stringResource(id = R.string.notes_search_label)) },
-                singleLine = true
-            )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            Row(
-                modifier = Modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                NotesList(
-                    notes = uiState.notes,
-                    selectedNoteId = uiState.selectedNoteId,
-                    onSelectNote = onSelectNote,
-                    modifier = Modifier.weight(1f)
-                )
-
-                NotesEditor(
-                    enabled = uiState.canInteractWithNotes,
-                    title = uiState.editorTitle,
-                    body = uiState.editorBody,
-                    onTitleChanged = onEditorTitleChanged,
-                    onBodyChanged = onEditorBodyChanged,
-                    modifier = Modifier.weight(1.2f)
+        item(key = "backup") {
+            StaggeredAppear(delayMillis = 60, modifier = Modifier.padding(horizontal = 16.dp)) {
+                BackupSyncCard(
+                    folderName = uiState.folderName,
+                    hasConfiguredFolder = uiState.hasConfiguredFolder,
+                    pendingSyncCount = uiState.pendingSyncCount,
+                    lastSyncEpochMs = uiState.lastSyncEpochMs,
+                    lastSyncError = uiState.lastSyncError,
+                    enabled = enabled,
+                    onSelectFolder = onSelectFolder,
+                    onResyncPending = onResyncPending,
+                    onExportNow = onExportNow,
+                    onImport = onImport,
                 )
             }
         }
 
-        if (uiState.isSaving) {
-            CircularProgressIndicator(modifier = Modifier.align(Alignment.BottomEnd))
+        // Stats + status share one item so the editor stays at a fixed index (EDITOR_ITEM_INDEX)
+        // for tap-to-scroll, and the status banner adds no phantom inter-item gap when idle.
+        item(key = "stats") {
+            StaggeredAppear(delayMillis = 120, modifier = Modifier.padding(horizontal = 16.dp)) {
+                Column {
+                    StatsStrip(
+                        notesCount = uiState.notesCount,
+                        pendingSyncCount = uiState.pendingSyncCount,
+                        isSaving = uiState.isSaving,
+                    )
+                    StatusBanner(statusKey = uiState.statusMessage, statusText = statusText)
+                }
+            }
+        }
+
+        item(key = "editor") {
+            StaggeredAppear(delayMillis = 180, modifier = Modifier.padding(horizontal = 16.dp)) {
+                EditorCard(
+                    enabled = enabled,
+                    hasSelectedNote = uiState.selectedNoteId != null,
+                    title = uiState.editorTitle,
+                    body = uiState.editorBody,
+                    onTitleChanged = onEditorTitleChanged,
+                    onBodyChanged = onEditorBodyChanged,
+                    onCreateNote = {
+                        onCreateNote()
+                        scrollToEditorSignal++
+                    },
+                    onSaveNow = onSaveNow,
+                    onDeleteSelected = { showDeleteDialog = true },
+                )
+            }
+        }
+
+        item(key = "search") {
+            StaggeredAppear(delayMillis = 220, modifier = Modifier.padding(horizontal = 16.dp)) {
+                OutlinedTextField(
+                    value = uiState.searchQuery,
+                    onValueChange = onSearchQueryChanged,
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text(text = stringResource(id = R.string.notes_search_label)) },
+                    leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null, tint = LbmBrown) },
+                    singleLine = true,
+                )
+            }
+        }
+
+        item(key = "list-header") {
+            StaggeredAppear(delayMillis = 260, modifier = Modifier.padding(horizontal = 16.dp)) {
+                SectionHeader(
+                    icon = Icons.Filled.Description,
+                    title = stringResource(id = R.string.notes_list_title),
+                    count = uiState.notesCount,
+                )
+            }
+        }
+
+        if (uiState.notes.isEmpty()) {
+            item(key = "list-empty") {
+                NotesEmptyState(
+                    isSearching = uiState.searchQuery.isNotBlank(),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+        } else {
+            items(uiState.notes, key = { it.id }) { note ->
+                NoteRow(
+                    note = note,
+                    selected = uiState.selectedNoteId == note.id,
+                    onClick = {
+                        onSelectNote(note.id)
+                        scrollToEditorSignal++
+                    },
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
         }
     }
 
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
+            icon = { Icon(Icons.Filled.DeleteOutline, contentDescription = null, tint = AccentCrimsonContent) },
             title = { Text(text = stringResource(id = R.string.notes_delete_confirm_title)) },
             text = { Text(text = stringResource(id = R.string.notes_delete_confirm_message)) },
             confirmButton = {
@@ -169,7 +275,10 @@ fun NotesScreen(
                         onDeleteSelected()
                     }
                 ) {
-                    Text(text = stringResource(id = R.string.notes_delete_confirm_action))
+                    Text(
+                        text = stringResource(id = R.string.notes_delete_confirm_action),
+                        color = AccentCrimsonContent,
+                    )
                 }
             },
             dismissButton = {
@@ -182,62 +291,129 @@ fun NotesScreen(
 }
 
 @Composable
-private fun HeroHeader(
+private fun BackupSyncCard(
     folderName: String?,
+    hasConfiguredFolder: Boolean,
     pendingSyncCount: Int,
     lastSyncEpochMs: Long?,
-    lastSyncError: String?
+    lastSyncError: String?,
+    enabled: Boolean,
+    onSelectFolder: () -> Unit,
+    onResyncPending: () -> Unit,
+    onExportNow: () -> Unit,
+    onImport: () -> Unit,
 ) {
-    Card(
-        shape = RoundedCornerShape(22.dp),
-        colors = CardDefaults.cardColors(containerColor = Color(0xFF1F4B6E)),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(id = R.string.notes_page_title),
-                style = MaterialTheme.typography.headlineSmall,
-                color = Color.White,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(id = R.string.notes_page_subtitle),
-                style = MaterialTheme.typography.bodyMedium,
-                color = Color(0xFFE8F0F6)
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            val folderLabel = folderName?.takeIf { it.isNotBlank() }
-                ?: stringResource(id = R.string.notes_folder_not_selected)
-            Text(
-                text = stringResource(id = R.string.notes_folder_selected_template, folderLabel),
-                style = MaterialTheme.typography.bodyMedium,
-                color = Color.White
-            )
-
-            val syncLabel = when {
-                !lastSyncError.isNullOrBlank() -> stringResource(id = R.string.notes_last_sync_error_label)
-                lastSyncEpochMs != null -> stringResource(
-                    id = R.string.notes_last_sync_success_template,
-                    formatEpoch(lastSyncEpochMs)
+    LessonCard(title = stringResource(R.string.notes_section_backup_title)) {
+        Surface(
+            shape = RoundedCornerShape(14.dp),
+            color = LbmSurfaceVariant,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(imageVector = Icons.Filled.Folder, contentDescription = null, tint = LbmBrown)
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = folderName?.takeIf { it.isNotBlank() }
+                        ?: stringResource(R.string.notes_folder_not_selected),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = LbmTextPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
-                else -> stringResource(id = R.string.notes_last_sync_never)
+                Spacer(Modifier.width(8.dp))
+                AccessDot(ready = hasConfiguredFolder)
             }
+        }
+
+        Spacer(Modifier.height(10.dp))
+
+        val syncLabel = when {
+            !lastSyncError.isNullOrBlank() -> stringResource(R.string.notes_last_sync_error_label)
+            lastSyncEpochMs != null -> stringResource(
+                R.string.notes_last_sync_success_template,
+                formatEpoch(lastSyncEpochMs),
+            )
+            else -> stringResource(R.string.notes_last_sync_never)
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = if (!lastSyncError.isNullOrBlank()) Icons.Filled.ErrorOutline else Icons.Filled.Sync,
+                contentDescription = null,
+                tint = if (!lastSyncError.isNullOrBlank()) AccentCrimsonContent else LbmTextSecondary,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(8.dp))
             Text(
                 text = syncLabel,
-                style = MaterialTheme.typography.bodySmall,
-                color = Color(0xFFD8E8F2)
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (!lastSyncError.isNullOrBlank()) AccentCrimsonContent else LbmTextSecondary,
             )
+        }
 
-            if (pendingSyncCount > 0) {
-                Text(
-                    text = stringResource(id = R.string.notes_pending_sync_template, pendingSyncCount),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFFFFE7B5)
-                )
+        AnimatedVisibility(visible = pendingSyncCount > 0) {
+            Box(modifier = Modifier.padding(top = 8.dp)) {
+                Surface(shape = RoundedCornerShape(10.dp), color = AccentGoldContainer) {
+                    Text(
+                        text = stringResource(R.string.notes_pending_sync_template, pendingSyncCount),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = AccentGoldContent,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                    )
+                }
             }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        IconActionButton(
+            icon = Icons.Filled.Folder,
+            label = stringResource(R.string.notes_action_select_folder),
+            onClick = onSelectFolder,
+            variant = ButtonVariant.PRIMARY,
+        )
+        Spacer(Modifier.height(8.dp))
+        IconActionButton(
+            icon = Icons.Filled.Sync,
+            label = stringResource(R.string.notes_action_resync_pending),
+            onClick = onResyncPending,
+            enabled = enabled,
+            variant = ButtonVariant.TONAL,
+        )
+        Spacer(Modifier.height(14.dp))
+        Text(
+            text = stringResource(R.string.notes_section_backup_actions_title),
+            style = MaterialTheme.typography.labelLarge,
+            color = LbmTextSecondary,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            IconActionButton(
+                icon = Icons.Filled.Upload,
+                label = stringResource(R.string.notes_action_export_now),
+                onClick = onExportNow,
+                enabled = enabled,
+                variant = ButtonVariant.OUTLINED,
+                modifier = Modifier.weight(1f),
+            )
+            IconActionButton(
+                icon = Icons.Filled.Download,
+                label = stringResource(R.string.notes_action_import_backup),
+                onClick = onImport,
+                enabled = enabled,
+                variant = ButtonVariant.OUTLINED,
+                modifier = Modifier.weight(1f),
+            )
         }
     }
 }
@@ -246,248 +422,446 @@ private fun HeroHeader(
 private fun StatsStrip(notesCount: Int, pendingSyncCount: Int, isSaving: Boolean) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         StatCard(
             modifier = Modifier.weight(1f),
-            title = stringResource(id = R.string.notes_stats_total_title),
-            value = notesCount.toString(),
-            accent = Color(0xFF385A7E)
-        )
+            title = stringResource(R.string.notes_stats_total_title),
+            container = LbmPrimaryContainer,
+            accent = LbmBrown,
+        ) {
+            StatValueText(notesCount.toString())
+        }
         StatCard(
             modifier = Modifier.weight(1f),
-            title = stringResource(id = R.string.notes_stats_pending_title),
-            value = pendingSyncCount.toString(),
-            accent = Color(0xFF8D5D2C)
-        )
+            title = stringResource(R.string.notes_stats_pending_title),
+            container = AccentGoldContainer,
+            accent = AccentGoldContent,
+        ) {
+            StatValueText(pendingSyncCount.toString())
+        }
         StatCard(
             modifier = Modifier.weight(1f),
-            title = stringResource(id = R.string.notes_stats_save_mode_title),
-            value = if (isSaving) {
-                stringResource(id = R.string.notes_stats_save_mode_saving)
-            } else {
-                stringResource(id = R.string.notes_stats_save_mode_idle)
-            },
-            accent = Color(0xFF2D7D58)
-        )
+            title = stringResource(R.string.notes_stats_save_mode_title),
+            container = AccentGreenContainer,
+            accent = AccentGreenContent,
+        ) {
+            AnimatedContent(
+                targetState = isSaving,
+                transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+                label = "saveState",
+            ) { saving ->
+                Text(
+                    text = stringResource(
+                        if (saving) R.string.notes_stats_save_mode_saving else R.string.notes_stats_save_mode_idle,
+                    ),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = LbmTextPrimary,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
     }
 }
 
 @Composable
-private fun StatCard(modifier: Modifier, title: String, value: String, accent: Color) {
-    Card(
+private fun StatCard(
+    title: String,
+    container: Color,
+    accent: Color,
+    modifier: Modifier = Modifier,
+    value: @Composable () -> Unit,
+) {
+    Surface(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White)
+        color = container,
     ) {
-        Column(modifier = Modifier.padding(10.dp)) {
+        Column(modifier = Modifier.padding(12.dp)) {
             Text(
                 text = title,
                 style = MaterialTheme.typography.labelMedium,
-                color = accent
+                color = accent,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = value,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
+            Spacer(Modifier.height(4.dp))
+            value()
         }
     }
 }
 
 @Composable
-private fun ActionBar(
-    enabled: Boolean,
-    onCreateNote: () -> Unit,
-    onDeleteSelected: () -> Unit,
-    onSaveNow: () -> Unit,
-    onExportNow: () -> Unit,
-    onImport: () -> Unit,
-    onSelectFolder: () -> Unit,
-    onResyncPending: () -> Unit
-) {
-    Card(
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(10.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Button(onClick = onCreateNote, enabled = enabled, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_new_note))
-                }
-                Button(onClick = onDeleteSelected, enabled = enabled, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_delete_note))
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Button(onClick = onSaveNow, enabled = enabled, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_save_now))
-                }
-                Button(onClick = onExportNow, enabled = enabled, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_export_now))
-                }
-                Button(onClick = onImport, enabled = enabled, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_import_backup))
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Button(onClick = onSelectFolder, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_select_folder))
-                }
-                Button(onClick = onResyncPending, enabled = enabled, modifier = Modifier.weight(1f)) {
-                    Text(text = stringResource(id = R.string.notes_action_resync_pending))
-                }
-            }
-        }
-    }
+private fun StatValueText(value: String) {
+    Text(
+        text = value,
+        style = MaterialTheme.typography.titleLarge,
+        color = LbmTextPrimary,
+        fontWeight = FontWeight.Bold,
+    )
 }
 
 @Composable
-private fun NotesList(
-    notes: List<NoteEntity>,
-    selectedNoteId: String?,
-    onSelectNote: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier,
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White)
+private fun StatusBanner(statusKey: String, statusText: String) {
+    AnimatedVisibility(
+        visible = statusText.isNotBlank(),
+        enter = fadeIn(tween(220)) + expandVertically(tween(220)),
+        exit = fadeOut(tween(160)) + shrinkVertically(tween(160)),
     ) {
-        Column(modifier = Modifier.padding(10.dp)) {
-            Text(
-                text = stringResource(id = R.string.notes_list_title),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            if (notes.isEmpty()) {
+        val visual = statusVisual(statusKey)
+        Surface(
+            shape = RoundedCornerShape(14.dp),
+            color = visual.container,
+            // Leading top space lives inside the animated content so it collapses with the banner
+            // when idle (no phantom gap below the stats strip).
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(imageVector = visual.icon, contentDescription = null, tint = visual.content)
+                Spacer(Modifier.width(10.dp))
                 Text(
-                    text = stringResource(id = R.string.notes_list_empty),
-                    style = MaterialTheme.typography.bodyMedium
+                    text = statusText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = visual.content,
                 )
-                return@Column
-            }
-
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(notes, key = { it.id }) { note ->
-                    val isSelected = selectedNoteId == note.id
-                    Card(
-                        shape = RoundedCornerShape(12.dp),
-                        colors = CardDefaults.cardColors(
-                            containerColor = if (isSelected) Color(0xFFE8F2FF) else Color(0xFFF8F9FD)
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = { onSelectNote(note.id) }
-                    ) {
-                        Column(modifier = Modifier.padding(10.dp)) {
-                            Text(
-                                text = note.title.ifBlank { stringResource(id = R.string.notes_untitled_note) },
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Medium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = note.body.ifBlank { stringResource(id = R.string.notes_body_placeholder_short) },
-                                style = MaterialTheme.typography.bodySmall,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = stringResource(
-                                    id = R.string.notes_updated_at_template,
-                                    formatEpoch(note.updatedAtEpochMs)
-                                ),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = Color(0xFF4A5D73)
-                            )
-                        }
-                    }
-                }
             }
         }
     }
 }
 
+private data class StatusVisual(val container: Color, val content: Color, val icon: ImageVector)
+
+private fun statusVisual(statusKey: String): StatusVisual = when (statusKey) {
+    "notes_status_resync_failed",
+    "notes_status_sync_failed_local_saved",
+    "notes_status_import_invalid_json",
+    "notes_status_import_read_failed",
+    "notes_status_folder_permission_error",
+    -> StatusVisual(AccentCrimsonContainer, AccentCrimsonContent, Icons.Filled.ErrorOutline)
+
+    "notes_status_resync_nothing",
+    "notes_status_sync_partial_pending",
+    -> StatusVisual(AccentGoldContainer, AccentGoldContent, Icons.Filled.Info)
+
+    else -> StatusVisual(AccentGreenContainer, AccentGreenContent, Icons.Filled.CheckCircle)
+}
+
 @Composable
-private fun NotesEditor(
+private fun EditorCard(
     enabled: Boolean,
+    hasSelectedNote: Boolean,
     title: String,
     body: String,
     onTitleChanged: (String) -> Unit,
     onBodyChanged: (String) -> Unit,
-    modifier: Modifier = Modifier
+    onCreateNote: () -> Unit,
+    onSaveNow: () -> Unit,
+    onDeleteSelected: () -> Unit,
 ) {
-    Card(
-        modifier = modifier,
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White)
+    LessonCard(title = stringResource(R.string.notes_editor_title)) {
+        Button(
+            onClick = onCreateNote,
+            enabled = enabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = LbmBrown, contentColor = Color.White),
+        ) {
+            ButtonContent(Icons.AutoMirrored.Filled.NoteAdd, stringResource(R.string.notes_action_new_note))
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = title,
+            onValueChange = onTitleChanged,
+            enabled = enabled,
+            label = { Text(text = stringResource(id = R.string.notes_editor_title_label)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = body,
+            onValueChange = onBodyChanged,
+            enabled = enabled,
+            label = { Text(text = stringResource(id = R.string.notes_editor_body_label)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 200.dp),
+            minLines = 8,
+        )
+
+        AnimatedVisibility(visible = enabled && !hasSelectedNote) {
+            EditorHint(
+                text = stringResource(R.string.notes_editor_no_note_hint),
+                color = LbmTextSecondary,
+            )
+        }
+        AnimatedVisibility(visible = !enabled) {
+            EditorHint(
+                text = stringResource(R.string.notes_folder_required_hint),
+                color = AccentCrimsonContent,
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            IconActionButton(
+                icon = Icons.Filled.Save,
+                label = stringResource(R.string.notes_action_save_now),
+                onClick = onSaveNow,
+                enabled = enabled && hasSelectedNote,
+                variant = ButtonVariant.TONAL,
+                modifier = Modifier.weight(1f),
+            )
+            IconActionButton(
+                icon = Icons.Filled.DeleteOutline,
+                label = stringResource(R.string.notes_action_delete_note),
+                onClick = onDeleteSelected,
+                enabled = enabled && hasSelectedNote,
+                variant = ButtonVariant.DANGER,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditorHint(text: String, color: Color) {
+    Row(
+        modifier = Modifier.padding(top = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Column(modifier = Modifier.padding(10.dp)) {
+        Icon(
+            imageVector = Icons.Filled.Info,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(text = text, style = MaterialTheme.typography.bodySmall, color = color)
+    }
+}
+
+@Composable
+private fun SectionHeader(icon: ImageVector, title: String, count: Int) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(imageVector = icon, contentDescription = null, tint = LbmBrown)
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = LbmTextPrimary,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.weight(1f),
+        )
+        Surface(shape = CircleShape, color = LbmPrimaryContainer) {
             Text(
-                text = stringResource(id = R.string.notes_editor_title),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
+                text = count.toString(),
+                style = MaterialTheme.typography.labelMedium,
+                color = LbmBrown,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
             )
-            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
 
-            OutlinedTextField(
-                value = title,
-                onValueChange = onTitleChanged,
-                enabled = enabled,
-                label = { Text(text = stringResource(id = R.string.notes_editor_title_label)) },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            OutlinedTextField(
-                value = body,
-                onValueChange = onBodyChanged,
-                enabled = enabled,
-                label = { Text(text = stringResource(id = R.string.notes_editor_body_label)) },
+@Composable
+private fun NoteRow(
+    note: NoteEntity,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val container by animateColorAsState(
+        targetValue = if (selected) LbmPrimaryContainer else LbmSurface,
+        label = "noteRowBg",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (selected) LbmBrown else LbmOutline,
+        label = "noteRowBorder",
+    )
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = container,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .animateContentSize(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                minLines = 10,
-                maxLines = 20
+                    .width(4.dp)
+                    .height(if (selected) 56.dp else 0.dp)
+                    .background(borderColor),
             )
-
-            if (!enabled) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = stringResource(id = R.string.notes_folder_required_hint),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Color(0xFF8A5A24)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                }
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text(
+                    text = note.title.ifBlank { stringResource(id = R.string.notes_untitled_note) },
+                    style = MaterialTheme.typography.titleSmall,
+                    color = LbmTextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = note.body.ifBlank { stringResource(id = R.string.notes_body_placeholder_short) },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = LbmTextSecondary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = stringResource(
+                        id = R.string.notes_updated_at_template,
+                        formatEpoch(note.updatedAtEpochMs),
+                    ),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = LbmBrown,
+                )
             }
         }
     }
+}
+
+@Composable
+private fun NotesEmptyState(isSearching: Boolean, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(64.dp)
+                .clip(CircleShape)
+                .background(LbmPrimaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = if (isSearching) Icons.Filled.Search else Icons.AutoMirrored.Filled.NoteAdd,
+                contentDescription = null,
+                tint = LbmBrown,
+                modifier = Modifier.size(30.dp),
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = stringResource(
+                if (isSearching) R.string.notes_list_no_results else R.string.notes_list_empty_title,
+            ),
+            style = MaterialTheme.typography.titleSmall,
+            color = LbmTextPrimary,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+        )
+        if (!isSearching) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.notes_list_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = LbmTextSecondary,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AccessDot(ready: Boolean) {
+    val dotCd = stringResource(
+        if (ready) R.string.notes_folder_status_ready else R.string.notes_folder_not_selected,
+    )
+    Box(
+        modifier = Modifier
+            .size(10.dp)
+            .clip(CircleShape)
+            .background(if (ready) AccentGreenContent else AccentCrimsonContent)
+            .semantics { contentDescription = dotCd },
+    )
+}
+
+private enum class ButtonVariant { PRIMARY, TONAL, OUTLINED, DANGER }
+
+@Composable
+private fun IconActionButton(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    variant: ButtonVariant,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    val buttonModifier = modifier
+        .fillMaxWidth()
+        .height(50.dp)
+    when (variant) {
+        ButtonVariant.PRIMARY -> Button(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = buttonModifier,
+            colors = ButtonDefaults.buttonColors(containerColor = LbmBrown, contentColor = Color.White),
+        ) { ButtonContent(icon, label) }
+
+        ButtonVariant.TONAL -> FilledTonalButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = buttonModifier,
+            colors = filledTonalColors(),
+        ) { ButtonContent(icon, label) }
+
+        ButtonVariant.OUTLINED -> OutlinedButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = buttonModifier,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = LbmBrown),
+        ) { ButtonContent(icon, label) }
+
+        ButtonVariant.DANGER -> OutlinedButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = buttonModifier,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = AccentCrimsonContent),
+        ) { ButtonContent(icon, label) }
+    }
+}
+
+@Composable
+private fun filledTonalColors(): ButtonColors = ButtonDefaults.filledTonalButtonColors(
+    containerColor = LbmSurfaceVariant,
+    contentColor = LbmTextPrimary,
+)
+
+@Composable
+private fun ButtonContent(icon: ImageVector, label: String) {
+    Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(18.dp))
+    Spacer(Modifier.width(8.dp))
+    Text(text = label, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
 }
 
 private fun formatEpoch(epochMs: Long): String {

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.NoteAdd
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Description
@@ -575,7 +575,7 @@ private fun EditorCard(
                 .height(52.dp),
             colors = ButtonDefaults.buttonColors(containerColor = LbmBrown, contentColor = Color.White),
         ) {
-            ButtonContent(Icons.AutoMirrored.Filled.NoteAdd, stringResource(R.string.notes_action_new_note))
+            ButtonContent(Icons.Filled.Add, stringResource(R.string.notes_action_new_note))
         }
 
         Spacer(Modifier.height(12.dp))
@@ -764,7 +764,7 @@ private fun NotesEmptyState(isSearching: Boolean, modifier: Modifier = Modifier)
             contentAlignment = Alignment.Center,
         ) {
             Icon(
-                imageVector = if (isSearching) Icons.Filled.Search else Icons.AutoMirrored.Filled.NoteAdd,
+                imageVector = if (isSearching) Icons.Filled.Search else Icons.Filled.Add,
                 contentDescription = null,
                 tint = LbmBrown,
                 modifier = Modifier.size(30.dp),

--- a/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
+++ b/app/src/main/java/com/johnchourp/learnbyzantinemusic/notes/ui/NotesScreen.kt
@@ -169,7 +169,6 @@ fun NotesScreen(
             StaggeredAppear(delayMillis = 60, modifier = Modifier.padding(horizontal = 16.dp)) {
                 BackupSyncCard(
                     folderName = uiState.folderName,
-                    hasConfiguredFolder = uiState.hasConfiguredFolder,
                     pendingSyncCount = uiState.pendingSyncCount,
                     lastSyncEpochMs = uiState.lastSyncEpochMs,
                     lastSyncError = uiState.lastSyncError,
@@ -294,7 +293,6 @@ fun NotesScreen(
 @Composable
 private fun BackupSyncCard(
     folderName: String?,
-    hasConfiguredFolder: Boolean,
     pendingSyncCount: Int,
     lastSyncEpochMs: Long?,
     lastSyncError: String?,
@@ -328,7 +326,9 @@ private fun BackupSyncCard(
                     modifier = Modifier.weight(1f),
                 )
                 Spacer(Modifier.width(8.dp))
-                AccessDot(ready = hasConfiguredFolder)
+                // Ready only when the folder is actually resolvable (folderName != null), so the dot
+                // can't show green while the row text reads «not selected» for a deleted/lost folder.
+                AccessDot(ready = !folderName.isNullOrBlank())
             }
         }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -801,7 +801,6 @@
     <string name="notes_page_title">My Notes</string>
     <string name="notes_page_subtitle">Write freely, save locally, and keep a full backup on every save.</string>
     <string name="notes_folder_not_selected">Backup folder not selected</string>
-    <string name="notes_folder_selected_template">Backup folder: %1$s</string>
     <string name="notes_last_sync_error_label">Last sync: failed (pending backups exist)</string>
     <string name="notes_last_sync_success_template">Last sync: %1$s</string>
     <string name="notes_last_sync_never">No sync completed yet</string>
@@ -849,6 +848,13 @@
     <string name="notes_status_import_invalid_json">Invalid backup file.</string>
     <string name="notes_status_import_read_failed">Failed to read backup file.</string>
     <string name="notes_status_folder_selected">Backup folder selected.</string>
+    <!-- Notes redesign (v1.14.0) — section titles, empty/a11y states -->
+    <string name="notes_section_backup_title">Backup &amp; sync folder</string>
+    <string name="notes_section_backup_actions_title">Backup actions</string>
+    <string name="notes_folder_status_ready">Backup folder is ready</string>
+    <string name="notes_list_empty_title">No notes yet</string>
+    <string name="notes_list_no_results">No notes match your search.</string>
+    <string name="notes_editor_no_note_hint">Create a new note to start writing.</string>
 
     <!-- Melody trainer -->
     <string name="title_activity_melody_trainer">Melody Trainer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -800,7 +800,6 @@
     <string name="notes_page_title">Οι Σημειώσεις Μου</string>
     <string name="notes_page_subtitle">Γράφε ελεύθερα, σώζε τοπικά και κράτα πλήρες backup σε κάθε αποθήκευση.</string>
     <string name="notes_folder_not_selected">Δεν έχει οριστεί φάκελος backup</string>
-    <string name="notes_folder_selected_template">Φάκελος backup: %1$s</string>
     <string name="notes_last_sync_error_label">Τελευταίο sync: αποτυχία (υπάρχουν εκκρεμή backups)</string>
     <string name="notes_last_sync_success_template">Τελευταίο sync: %1$s</string>
     <string name="notes_last_sync_never">Δεν έχει ολοκληρωθεί sync ακόμη</string>
@@ -848,6 +847,13 @@
     <string name="notes_status_import_invalid_json">Μη έγκυρο backup αρχείο.</string>
     <string name="notes_status_import_read_failed">Αποτυχία ανάγνωσης backup αρχείου.</string>
     <string name="notes_status_folder_selected">Ο φάκελος backup επιλέχθηκε.</string>
+    <!-- Notes redesign (v1.14.0) — section titles, empty/a11y states -->
+    <string name="notes_section_backup_title">Φάκελος backup &amp; sync</string>
+    <string name="notes_section_backup_actions_title">Ενέργειες backup</string>
+    <string name="notes_folder_status_ready">Ο φάκελος backup είναι έτοιμος</string>
+    <string name="notes_list_empty_title">Καμία σημείωση ακόμη</string>
+    <string name="notes_list_no_results">Δεν βρέθηκαν σημειώσεις για την αναζήτηση.</string>
+    <string name="notes_editor_no_note_hint">Δημιούργησε μια νέα σημείωση για να ξεκινήσεις να γράφεις.</string>
 
     <!-- Melody trainer (Γυμναστής Μελωδίας) -->
     <string name="title_activity_melody_trainer">Γυμναστής Μελωδίας</string>


### PR DESCRIPTION
## Τι αλλάζει

Πλήρης ανασχεδιασμός της σελίδας **«Οι Σημειώσεις Μου»** (`NotesScreen` / `NotesActivity`) και **όλων των components που χρησιμοποιεί**, πάνω στο κοινό **Compose design system** (`LbmTheme` + `LessonHero` + `LessonCard` + `StaggeredAppear` + ζεστή βυζαντινή παλέτα). Στόχος: φιλική, κατανοητή, όμορφη, animated, phone-first σελίδα — ο χρήστης καταλαβαίνει τα πάντα μέσα στη σελίδα.

> **Pure rendering change.** Καμία αλλαγή σε `NotesViewModel` / `NotesRepository` / DAO / codec / policies — ίδιο callback contract, ίδια λογική αποθήκευσης/backup/sync.

## Πριν → Μετά (βασικά)

- **Theme:** raw `MaterialTheme {}` + μπλε hard-coded χρώματα → `LbmTheme {}` + brand palette.
- **Navigation:** χωρίς back → `LessonHero` με back button.
- **Layout:** στριμωγμένο side-by-side `Row` (λίστα + editor) → single-column `LazyColumn`, phone-first.
- **Backup/sync:** σκόρπιο κείμενο στο hero + 7 αδιαφοροποίητα text-only κουμπιά → ένα card «Φάκελος backup &amp; sync» με φάκελο + ready/missing dot, τελευταίο sync, pending badge και ομαδοποιημένες ενέργειες (Επιλογή φακέλου / Επανασυγχρονισμός / Εξαγωγή / Import) με icons.
- **Editor:** μισό πλάτος, αδιάβαστος → card «Επεξεργασία» full-width με γενναίο ύψος και primary actions «Νέα / Save / Διαγραφή» (icons + disabled hints).
- **Λίστα:** μία γραμμή κειμένου → rows με animated selection, preview/updated-at, tap → auto-scroll στον editor, και empty / no-results states.
- **Stats:** branded cards + animated «Κατάσταση» (Έτοιμο ↔ Αποθήκευση…).
- **Status:** στατικό card → animated banner (χρώμα/εικονίδιο ανά τύπο μηνύματος).

## Animations

`StaggeredAppear` entrance · hero pulse · `animateColorAsState` selection · `animateContentSize` · `AnimatedContent` («Κατάσταση») · `AnimatedVisibility` (status banner, saving bar, hints).

## Strings

Νέα keys σε **EL default + EN parity** (section titles, empty/no-results, a11y, editor hint). Αφαιρέθηκε το πλέον ορφανό `notes_folder_selected_template`. Parity επιβεβαιωμένη (57/57 `notes_*`).

## Validation

- `./gradlew testDebugUnitTest` ✅ (τα 4 Notes data-layer tests μένουν πράσινα)
- `./gradlew assembleDebug` ✅
- `./gradlew assembleRelease` ✅ (R8/minify + `lintVitalRelease`, χωρίς warnings)
- `./scripts/check-no-secrets.sh` ✅
- Pre-PR adversarial multi-lens review (behavioral-regression / Compose-correctness / layout-a11y / strings-build) — 2 confirmed P3 διορθώθηκαν (phantom idle gap + unused new string), 3 nits απορρίφθηκαν τεκμηριωμένα.

## Version

`versionName 1.14.0` / `versionCode 51`.

## ClickUp

Parent task **869dwnp3w** (S1–S16).
